### PR TITLE
Fix CI git fetch error in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           ref: art-data
           path: public/data
+          fetch-tags: false
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
Fixed a CI failure where `actions/checkout` failed with exit code 1 during `git fetch`.
The failure was caused by the action trying to fetch tags for the `art-data` branch.
Added `fetch-tags: false` to the `Checkout Art Data` step in `.github/workflows/deploy.yml` to prevent this behavior.

---
*PR created automatically by Jules for task [8688499554946465863](https://jules.google.com/task/8688499554946465863) started by @HereLiesAz*

## Summary by Sourcery

Bug Fixes:
- Prevent CI failures in the deploy workflow caused by git fetch errors when checking out the art-data branch.