### PR TITLE
fix(ci): use explicit refspec for art-data checkout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout Art Data
         uses: actions/checkout@v4
         with:
-          ref: art-data
+          ref: refs/heads/art-data
           path: public/data
           fetch-tags: false
 


### PR DESCRIPTION
Updated `.github/workflows/deploy.yml` to use `ref: refs/heads/art-data` instead of `ref: art-data`. This prevents `actions/checkout` from constructing ambiguous refspecs that caused the fetch to fail.

---
*PR created automatically by Jules for task [7087188272437324387](https://jules.google.com/task/7087188272437324387) started by @HereLiesAz*

## Summary by Sourcery

Clarify the branch ref used when checking out art data in the deployment workflow to avoid ambiguous refspecs.

Bug Fixes:
- Fix deployment workflow checkout of the art-data branch by using an explicit heads ref to prevent ambiguous refspec errors.

CI:
- Adjust deploy workflow checkout configuration to reference refs/heads/art-data instead of the short branch name.