### PR TITLE
fix: unblock blank gallery — bake theater layers in CI + flat fallback

### DIFF
--- a/.github/workflows/process_art.yml
+++ b/.github/workflows/process_art.yml
@@ -4,9 +4,10 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - 'assets/raw/**'
+      - 'public/assets/**'
       - 'scripts/grinder.py'
       - 'scripts/indexer.py'
+      - 'scripts/theater_baker.py'
       - 'scripts/requirements.txt'
 
 # Cancel previous runs if you push again (prevents queue jams)
@@ -55,7 +56,7 @@ jobs:
       - name: Run Grinder (Turbo Mode)
         run: |
           # Added --fast flag for 16x speedup
-          python scripts/grinder.py --input assets/raw --out temp_data --shard_index ${{ matrix.shard }} --total_shards 56 --fast
+          python scripts/grinder.py --input public/assets --out temp_data --shard_index ${{ matrix.shard }} --total_shards 56 --fast
 
       - name: Upload Shard
         uses: actions/upload-artifact@v4

--- a/.github/workflows/process_art.yml
+++ b/.github/workflows/process_art.yml
@@ -85,6 +85,17 @@ jobs:
       - name: Index
         run: python scripts/indexer.py
 
+      - name: Bake Theater Layers
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "::warning::HF_TOKEN secret is not set; theater bake will skip the depth Space and likely fail. Add HF_TOKEN under repo Settings → Secrets → Actions."
+          fi
+          python scripts/theater_baker.py \
+            --input  public/assets/ \
+            --output public/data/theater/
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
@@ -92,4 +103,4 @@ jobs:
           publish_dir: ./public/data
           publish_branch: art-data
           keep_files: true
-          commit_message: "Turbo Grind: ${{ github.sha }}"
+          commit_message: "Turbo Grind + Theater Bake: ${{ github.sha }}"

--- a/.github/workflows/process_art.yml
+++ b/.github/workflows/process_art.yml
@@ -90,7 +90,8 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           if [ -z "$HF_TOKEN" ]; then
-            echo "::warning::HF_TOKEN secret is not set; theater bake will skip the depth Space and likely fail. Add HF_TOKEN under repo Settings → Secrets → Actions."
+            echo "::warning::HF_TOKEN secret is not set — skipping theater bake. Add HF_TOKEN under repo Settings → Secrets → Actions to enable it."
+            exit 0
           fi
           python scripts/theater_baker.py \
             --input  public/assets/ \

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -50,12 +50,12 @@ class ArtGrinder:
 
     def _load_depth_model(self):
         try:
-            return torch.hub.load("isl-org/ZoeDepth", "ZoeD_N", pretrained=True).to(self.device).eval()
+            return torch.hub.load("isl-org/ZoeDepth", "ZoeD_N", pretrained=True, trust_repo=True).to(self.device).eval()
         except Exception:
-            return torch.hub.load("intel-isl/MiDaS", "DPT_Large").to(self.device).eval()
+            return torch.hub.load("intel-isl/MiDaS", "DPT_Large", trust_repo=True).to(self.device).eval()
 
     def _load_depth_transform(self):
-        transforms = torch.hub.load("intel-isl/MiDaS", "transforms")
+        transforms = torch.hub.load("intel-isl/MiDaS", "transforms", trust_repo=True)
         return transforms.dpt_transform if self.device == 'cuda' else transforms.small_transform
 
     def get_depth_map(self, img_rgb):

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -5,6 +5,7 @@ pillow-heif
 scipy
 timm
 huggingface_hub
+gradio_client
 git+https://github.com/facebookresearch/segment-anything.git
 # Torch/Torchvision for local dev (CI uses command line for CPU)
 torch

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -23,7 +23,7 @@ export default function Scene() {
       .then(r => (r.ok ? r.json() : []))
       .then(manifest => {
         if (!Array.isArray(manifest) || manifest.length === 0) return null;
-        return manifest.map(id => ({ id, image: `${id}.painting.webp`, title: id, theater: true }));
+        return manifest.map(id => ({ id, image: "/data/theater/" + encodeURIComponent(id) + ".painting.webp", title: id, theater: true }));
       })
       .catch(() => null);
 

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -10,24 +10,53 @@ export default function Scene() {
   const setGraph = useStore(state => state.setGraph);
   const setStartNode = useStore(state => state.setStartNode);
 
-  // The walker reads /data/theater/_manifest.json for the list of baked
-  // paintings and synthesizes a minimal graph (nodes only, no edges) — the
-  // store's stochastic next-node picker falls back to random-other-node
-  // when an id has no outgoing edges, which is exactly what we want until
-  // a pareidolia indexer for the new layered schema lands.
+  // Primary path: the walker reads /data/theater/_manifest.json for the list
+  // of baked paintings and synthesizes a minimal graph (nodes only, no edges).
+  // Fallback: if the theater bake hasn't run yet (manifest missing or empty),
+  // load /graph.json — the legacy pareidolia graph — so the gallery degrades
+  // to flat textured planes instead of going pitch-black. TheaterPainting
+  // renders a single plane from /assets/{image} when no theater.json is
+  // present for a node.
   useEffect(() => {
-    fetch('/data/theater/_manifest.json')
+    let cancelled = false;
+    const loadFromTheater = fetch('/data/theater/_manifest.json')
       .then(r => (r.ok ? r.json() : []))
       .then(manifest => {
-        if (!Array.isArray(manifest) || manifest.length === 0) {
-          console.warn("[Scene] _manifest.json is empty; bake some paintings via scripts/theater_baker.py.");
+        if (!Array.isArray(manifest) || manifest.length === 0) return null;
+        return manifest.map(id => ({ id, image: `${id}.painting.webp`, title: id, theater: true }));
+      })
+      .catch(() => null);
+
+    const loadFromGraph = () => fetch('/graph.json')
+      .then(r => (r.ok ? r.json() : null))
+      .then(g => {
+        if (!g || !Array.isArray(g.nodes) || g.nodes.length === 0) return null;
+        const nodes = g.nodes.map(n => ({ ...n, theater: false }));
+        return { nodes, edges: Array.isArray(g.edges) ? g.edges : [] };
+      })
+      .catch(() => null);
+
+    loadFromTheater
+      .then(nodes => {
+        if (cancelled) return;
+        if (nodes && nodes.length > 0) {
+          setGraph({ schemaVersion: 4, nodes, edges: [] });
+          setStartNode(nodes[0].id);
           return;
         }
-        const nodes = manifest.map(id => ({ id, image: `${id}.painting.webp`, title: id }));
-        setGraph({ schemaVersion: 4, nodes, edges: [] });
-        setStartNode(nodes[0].id);
-      })
-      .catch(err => console.error("Manifest Load Error:", err));
+        console.warn("[Scene] theater manifest missing/empty; falling back to graph.json.");
+        return loadFromGraph().then(g => {
+          if (cancelled) return;
+          if (!g) {
+            console.error("[Scene] No theater bake and no graph.json — gallery cannot render.");
+            return;
+          }
+          setGraph({ schemaVersion: 2, nodes: g.nodes, edges: g.edges });
+          setStartNode(g.nodes[0].id);
+        });
+      });
+
+    return () => { cancelled = true; };
   }, [setGraph, setStartNode]);
 
   const currentSegmentIndex = useStore(state => state.currentSegmentIndex);
@@ -56,6 +85,7 @@ export default function Scene() {
                         <TheaterPainting
                             key={`${cluster.id}-${cluster.index}`}
                             id={cluster.id}
+                            image={cluster.image}
                             position={cluster.worldPos}
                             rotation={cluster.rotSway}
                             mySegmentIndex={cluster.index}

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -31,7 +31,7 @@ export default function Scene() {
       .then(r => (r.ok ? r.json() : null))
       .then(g => {
         if (!g || !Array.isArray(g.nodes) || g.nodes.length === 0) return null;
-        const nodes = g.nodes.map(n => ({ ...n, theater: false }));
+        const nodes = g.nodes.map(n => ({ ...n, image: "/assets/" + encodeURIComponent(n.image), theater: false }));
         return { nodes, edges: Array.isArray(g.edges) ? g.edges : [] };
       })
       .catch(() => null);

--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -135,8 +135,9 @@ function buildLayers(metadata) {
 
 // ---- component --------------------------------------------------------------
 
-export default function TheaterPainting({ id, position, rotation, mySegmentIndex }) {
+export default function TheaterPainting({ id, image, position, rotation, mySegmentIndex }) {
   const [meta, setMeta] = useState(null);
+  const [flatTex, setFlatTex] = useState(null);
   const currentSegmentIndex = useStore(s => s.currentSegmentIndex);
   const setCurrentResolution = useStore(s => s.setCurrentResolution);
   const tmpVec = useRef(new THREE.Vector3());
@@ -144,9 +145,31 @@ export default function TheaterPainting({ id, position, rotation, mySegmentIndex
   useEffect(() => {
     if (!id) return;
     let cancelled = false;
-    fetchTheaterMeta(id).then(json => { if (!cancelled) setMeta(json); });
+    fetchTheaterMeta(id).then(json => {
+      if (cancelled) return;
+      setMeta(json);
+      // Flat fallback: when the theater bake hasn't run for this id, render
+      // the original asset image as a single textured plane instead of the
+      // 30-layer shell. Looks like the legacy gallery — no parallax, no
+      // colour-bleed shader — but the page isn't blank.
+      if (!json && image) {
+        const loader = new THREE.TextureLoader();
+        loader.load(
+          `/assets/${encodeURIComponent(image)}`,
+          tex => {
+            if (cancelled) { tex.dispose(); return; }
+            tex.colorSpace = THREE.SRGBColorSpace;
+            const w = tex.image?.width || 1;
+            const h = tex.image?.height || 1;
+            setFlatTex({ texture: tex, aspect: w / h, width: w, height: h });
+          },
+          undefined,
+          () => { /* image missing — render nothing for this id */ },
+        );
+      }
+    });
     return () => { cancelled = true; };
-  }, [id]);
+  }, [id, image]);
 
   const rotEuler = useMemo(() => {
     const r = rotation || [0, 0, 0];
@@ -288,6 +311,35 @@ export default function TheaterPainting({ id, position, rotation, mySegmentIndex
     planeGeom.dispose();
   }, [baseMaterial, planeGeom]);
 
+  useEffect(() => () => {
+    if (flatTex?.texture) flatTex.texture.dispose();
+  }, [flatTex]);
+
+  // Flat-mode fit: same screen-fit logic as the layered shell, but using the
+  // raw image aspect (no theater.json) since we have no per-painting metadata.
+  const flatFitScale = useMemo(() => {
+    if (!flatTex) return 1.0;
+    const paintingWidth  = PAINTING_HEIGHT * flatTex.aspect;
+    const paintingHeight = PAINTING_HEIGHT;
+    const distance = SHELL_FRONT;
+    const vFov = THREE.MathUtils.degToRad(camera.fov);
+    const visibleHeight = 2.0 * distance * Math.tan(vFov / 2.0);
+    const visibleWidth = visibleHeight * (size.width / size.height);
+    const widthScale  = (visibleWidth  * 0.85) / paintingWidth;
+    const heightScale = (visibleHeight * 0.90) / paintingHeight;
+    return Math.min(widthScale, heightScale);
+  }, [flatTex, size.width, size.height, camera.fov]);
+
+  // Push flat-mode resolution to the store so the overlay & shard count
+  // stay coherent even without a theater bake.
+  useEffect(() => {
+    const isActiveSegment =
+      mySegmentIndex === currentSegmentIndex ||
+      mySegmentIndex === currentSegmentIndex + 1;
+    if (!isActiveSegment || meta || !flatTex) return;
+    setCurrentResolution([flatTex.width, flatTex.height]);
+  }, [mySegmentIndex, currentSegmentIndex, meta, flatTex, setCurrentResolution]);
+
   // Camera distance → fade and colour-bleed envelope. Inside COLOR_HOT the
   // painting is at full saturation; past COLOR_GONE the hue is bone-white
   // only; past FADE_GONE the painting is invisible.
@@ -305,6 +357,23 @@ export default function TheaterPainting({ id, position, rotation, mySegmentIndex
       m.uniforms.uColorBleed.value = bleed;
     }
   });
+
+  // Flat fallback render — single textured plane at the shell-front depth.
+  if (!meta && flatTex) {
+    const fw = PAINTING_HEIGHT * flatTex.aspect * flatFitScale;
+    const fh = PAINTING_HEIGHT * flatFitScale;
+    return (
+      <group position={position} rotation={rotEuler}>
+        <mesh
+          geometry={planeGeom}
+          position={[0, 0, -SHELL_FRONT]}
+          scale={[fw, fh, 1]}
+        >
+          <meshBasicMaterial map={flatTex.texture} toneMapped={false} />
+        </mesh>
+      </group>
+    );
+  }
 
   if (!meta || layers.length === 0 || planeMaterials.length === 0) return null;
 

--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -182,35 +182,30 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
 
   const layers = useMemo(() => meta ? buildLayers(meta) : [], [meta]);
 
-  // Calculate dynamic scale to fit the painting into the screen
+  // Calculate dynamic scale to fit the painting into the screen at SHELL_FRONT.
+  // Same math regardless of whether the layered shell or the flat fallback is
+  // rendering — only the source of the aspect ratio differs (theater.json vs.
+  // the raw asset image dimensions).
   const { size, camera } = useThree();
   const fitScale = useMemo(() => {
-    if (!meta || layers.length === 0) return 1.0;
+    let paintingWidth, paintingHeight;
+    if (meta && layers.length > 0) {
+      paintingWidth  = layers[0].planeWidth;
+      paintingHeight = layers[0].planeHeight;
+    } else if (flatTex) {
+      paintingWidth  = PAINTING_HEIGHT * flatTex.aspect;
+      paintingHeight = PAINTING_HEIGHT;
+    } else {
+      return 1.0;
+    }
 
-    // The base plane dimensions are determined in buildLayers.
-    // They represent the world-space size of the painting BEFORE any scaling.
-    const L = layers[0];
-    const paintingWidth = L.planeWidth;
-    const paintingHeight = L.planeHeight;
-
-    // Calculate the visible world bounds at the viewing distance (SHELL_FRONT).
-    // Note: camera.fov is vertical fov in degrees.
-    const distance = SHELL_FRONT;
     const vFov = THREE.MathUtils.degToRad(camera.fov);
-    const visibleHeight = 2.0 * distance * Math.tan(vFov / 2.0);
-    const visibleWidth = visibleHeight * (size.width / size.height);
-
-    // We want the painting to fit comfortably within the screen, with some padding.
-    // 90% of screen height and 85% of screen width.
-    const maxAllowedWidth = visibleWidth * 0.85;
-    const maxAllowedHeight = visibleHeight * 0.90;
-
-    const widthScale = maxAllowedWidth / paintingWidth;
-    const heightScale = maxAllowedHeight / paintingHeight;
-
-    // Choose the scale that satisfies both constraints
+    const visibleHeight = 2.0 * SHELL_FRONT * Math.tan(vFov / 2.0);
+    const visibleWidth  = visibleHeight * (size.width / size.height);
+    const widthScale  = (visibleWidth  * 0.85) / paintingWidth;
+    const heightScale = (visibleHeight * 0.90) / paintingHeight;
     return Math.min(widthScale, heightScale);
-  }, [meta, layers, size.width, size.height, camera.fov]);
+  }, [meta, layers, flatTex, size.width, size.height, camera.fov]);
 
   // Shared material across all 30 planes of this painting. Per-plane data
   // (layer index, channel) goes through onBeforeCompile-free attribute
@@ -283,14 +278,20 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     }
   }, [textures, planeMaterials]);
 
-  // Sync metadata for the active painting.
+  // Push the active painting's source resolution to the store so the overlay
+  // & shard count stay coherent. Works for both modes: prefer the theater
+  // metadata's src dims, fall back to the flat texture's natural dims.
   useEffect(() => {
     const isActiveSegment =
       mySegmentIndex === currentSegmentIndex ||
       mySegmentIndex === currentSegmentIndex + 1;
-    if (!isActiveSegment || !meta) return;
-    setCurrentResolution([meta.src?.width || 1000, meta.src?.height || 1000]);
-  }, [mySegmentIndex, currentSegmentIndex, meta, setCurrentResolution]);
+    if (!isActiveSegment) return;
+    if (meta) {
+      setCurrentResolution([meta.src?.width || 1000, meta.src?.height || 1000]);
+    } else if (flatTex) {
+      setCurrentResolution([flatTex.width, flatTex.height]);
+    }
+  }, [mySegmentIndex, currentSegmentIndex, meta, flatTex, setCurrentResolution]);
 
   // Dispose per-painting resources when the component unmounts or the id
   // swaps. baseMaterial and planeGeom are tied to the component lifetime;
@@ -315,34 +316,22 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     if (flatTex?.texture) flatTex.texture.dispose();
   }, [flatTex]);
 
-  // Flat-mode fit: same screen-fit logic as the layered shell, but using the
-  // raw image aspect (no theater.json) since we have no per-painting metadata.
-  const flatFitScale = useMemo(() => {
-    if (!flatTex) return 1.0;
-    const paintingWidth  = PAINTING_HEIGHT * flatTex.aspect;
-    const paintingHeight = PAINTING_HEIGHT;
-    const distance = SHELL_FRONT;
-    const vFov = THREE.MathUtils.degToRad(camera.fov);
-    const visibleHeight = 2.0 * distance * Math.tan(vFov / 2.0);
-    const visibleWidth = visibleHeight * (size.width / size.height);
-    const widthScale  = (visibleWidth  * 0.85) / paintingWidth;
-    const heightScale = (visibleHeight * 0.90) / paintingHeight;
-    return Math.min(widthScale, heightScale);
-  }, [flatTex, size.width, size.height, camera.fov]);
-
-  // Push flat-mode resolution to the store so the overlay & shard count
-  // stay coherent even without a theater bake.
+  // Shared material for the flat fallback. Created once and updated per-frame
+  // so it picks up the same distance fade as the layered shell.
+  const flatMaterial = useMemo(
+    () => new THREE.MeshBasicMaterial({ transparent: true, toneMapped: false }),
+    [],
+  );
+  useEffect(() => () => flatMaterial.dispose(), [flatMaterial]);
   useEffect(() => {
-    const isActiveSegment =
-      mySegmentIndex === currentSegmentIndex ||
-      mySegmentIndex === currentSegmentIndex + 1;
-    if (!isActiveSegment || meta || !flatTex) return;
-    setCurrentResolution([flatTex.width, flatTex.height]);
-  }, [mySegmentIndex, currentSegmentIndex, meta, flatTex, setCurrentResolution]);
+    if (flatTex) flatMaterial.map = flatTex.texture;
+    flatMaterial.needsUpdate = true;
+  }, [flatTex, flatMaterial]);
 
   // Camera distance → fade and colour-bleed envelope. Inside COLOR_HOT the
   // painting is at full saturation; past COLOR_GONE the hue is bone-white
-  // only; past FADE_GONE the painting is invisible.
+  // only; past FADE_GONE the painting is invisible. Flat-fallback material
+  // gets the same fade as opacity so it dissolves rather than popping out.
   useFrame(() => {
     if (!position) return;
     const v = tmpVec.current;
@@ -356,21 +345,21 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
       m.uniforms.uIntensity.value  = fade;
       m.uniforms.uColorBleed.value = bleed;
     }
+    flatMaterial.opacity = fade;
   });
 
   // Flat fallback render — single textured plane at the shell-front depth.
   if (!meta && flatTex) {
-    const fw = PAINTING_HEIGHT * flatTex.aspect * flatFitScale;
-    const fh = PAINTING_HEIGHT * flatFitScale;
+    const fw = PAINTING_HEIGHT * flatTex.aspect * fitScale;
+    const fh = PAINTING_HEIGHT * fitScale;
     return (
       <group position={position} rotation={rotEuler}>
         <mesh
           geometry={planeGeom}
+          material={flatMaterial}
           position={[0, 0, -SHELL_FRONT]}
           scale={[fw, fh, 1]}
-        >
-          <meshBasicMaterial map={flatTex.texture} toneMapped={false} />
-        </mesh>
+        />
       </group>
     );
   }

--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -155,7 +155,7 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
       if (!json && image) {
         const loader = new THREE.TextureLoader();
         loader.load(
-          `/assets/${encodeURIComponent(image)}`,
+          image,
           tex => {
             if (cancelled) { tex.dispose(); return; }
             tex.colorSpace = THREE.SRGBColorSpace;

--- a/src/store/useStore.jsx
+++ b/src/store/useStore.jsx
@@ -32,12 +32,14 @@ const useStore = create((set, get) => ({
 
   setStartNode: (id) => {
     console.log("[Store] Starting at:", id);
-    const firstCluster = { id, worldPos: [0, 0, 0] };
-    set({ 
-        activeClusters: [firstCluster], 
+    const { nodes } = get();
+    const node = nodes.find(n => n.id === id);
+    const firstCluster = { id, worldPos: [0, 0, 0], image: node?.image };
+    set({
+        activeClusters: [firstCluster],
         currentNodeId: id,
         segments: [],
-        currentSegmentIndex: 0 
+        currentSegmentIndex: 0
     });
     get().buildNextSegment();
   },
@@ -110,11 +112,13 @@ const useStore = create((set, get) => ({
     // 5–12 % off-axis — visible parallax without losing the painting.
     const swerveDist = 1.0 + Math.random() * 1.5;
 
+    const nextNode = nodes.find(n => n.id === nextId);
     const nextCluster = {
         id: nextId,
         worldPos: nextPos,
         anchorId: undefined,
         rotSway,
+        image: nextNode?.image,
     };
     
     // 3. Camera Spline


### PR DESCRIPTION
## Why the site was blank

`Scene.jsx` walks `/data/theater/_manifest.json`, which is produced by `scripts/theater_baker.py`. The deploy workflow checks the `art-data` branch out into `public/data/`. But `process_art.yml` only ran `grinder.py` + `indexer.py` — the **baker step was never wired in**, so the `art-data` branch has 4,070 grinder JSONs and zero `theater/` files. Production 404'd the manifest, `Scene.jsx` early-returned without calling `setStartNode`, and the Canvas mounted with no paintings behind the static "HereLiesAz" SVG signature.

## Changes

### 1. CI bake step (`process_art.yml`, `scripts/requirements.txt`)
Runs `theater_baker.py --input public/assets/ --output public/data/theater/` between `indexer` and the `gh-pages` deploy. Adds `gradio_client` to requirements (used by the baker to call the Depth-Anything-V2 HF Space).

**Requires `HF_TOKEN` to be added as a repo secret** (Settings → Secrets → Actions). Without it the Space rejects the depth request and the bake fails. The workflow emits a warning if the secret is unset.

### 2. Graph fallback in `Scene.jsx` + `useStore.jsx`
If `/data/theater/_manifest.json` is missing or empty, fall back to `/graph.json` (the legacy pareidolia graph, already shipped in the repo root). The image filename now rides through node → cluster → `TheaterPainting`.

### 3. Flat-mode render in `TheaterPainting.jsx`
When no per-painting `theater.json` is present, render the asset image at `/assets/{image}` as a single `MeshBasicMaterial` plane at the shell-front depth, using the same screen-fit math as the layered shell. No parallax, no colour-bleed shader — looks like the legacy gallery — but the page is no longer blank.

## Effect

- **Immediately after merge:** site renders the flat gallery from `graph.json` (15 nodes shipped in-repo) even before any bake runs.
- **After `HF_TOKEN` secret is added and Process Art runs:** baked paintings replace the flat fallback automatically, the layered shell comes back online.

## Test plan
- [x] `npm run build` passes (620 modules, no errors)
- [ ] Manual: visit deploy preview / production — confirm paintings render (flat mode) instead of black screen
- [ ] Add `HF_TOKEN` secret, trigger Process Art workflow, confirm `theater/_manifest.json` lands on `art-data`
- [ ] Visit production again — confirm layered shell renders (parallax, colour bleed)

## Out of scope
- The one-shot local bake couldn't run in this remote environment — `huggingface.co` is blocked by the sandbox network policy. The CI fix + token secret is the path forward.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fu1Rn9mzfwm214MrX6aq8q)_

## Summary by Sourcery

Restore gallery rendering by adding a CI bake step for theater data and introducing a flat-image fallback path when baked metadata is missing.

New Features:
- Add a flat rendering mode that displays paintings as single textured planes when theater metadata is unavailable.
- Support loading the gallery graph from the legacy graph.json when the theater manifest is missing or empty.

Bug Fixes:
- Prevent the gallery from rendering a blank screen when theater bake outputs are absent in production by falling back to in-repo graph data and flat painting renders.

Enhancements:
- Propagate image filenames through graph nodes and clusters so TheaterPainting can render either baked layers or flat assets consistently.
- Ensure render resolution state stays coherent in flat mode by updating it from the loaded image dimensions.

Build:
- Extend the process_art CI workflow to run the theater_baker script and adjust the deployed commit message.
- Update scripts requirements to include gradio_client for the theater baking pipeline.