### PR TITLE
fix: install python deps in process_art consolidate job

### DIFF
--- a/.github/workflows/process_art.yml
+++ b/.github/workflows/process_art.yml
@@ -82,6 +82,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install Dependencies
+        run: pip install -r scripts/requirements.txt
 
       - name: Index
         run: python scripts/indexer.py


### PR DESCRIPTION
Follow-up to #32. The `consolidate` job in `process_art.yml` sets up Python 3.10 but never runs `pip install -r scripts/requirements.txt`, so the bake step added in #32 crashed on `ModuleNotFoundError: No module named 'cv2'`.

Adds the same `pip install` + pip cache that the `grind` job already has.

## Test plan
- [ ] Trigger Process Art workflow (manually or via a path-watched change). Confirm consolidate job runs `Install Dependencies` and the bake step proceeds past the import.
- [ ] With `HF_TOKEN` secret set, confirm bake produces `theater/_manifest.json` + per-painting outputs on `art-data` branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fu1Rn9mzfwm214MrX6aq8q)_