### PR TITLE
Make theater flats double-sided

### DIFF
--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -334,7 +334,7 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
   // Shared material for the flat fallback. Created once and updated per-frame
   // so it picks up the same distance fade as the layered shell.
   const fallbackMaterial = useMemo(
-    () => new THREE.MeshBasicMaterial({ toneMapped: false }),
+    () => new THREE.MeshBasicMaterial({ toneMapped: false, side: THREE.DoubleSide }),
     [],
   );
   useEffect(() => () => fallbackMaterial.dispose(), [fallbackMaterial]);

--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -243,6 +243,10 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     fragmentShader: flatFS,
     transparent:    false,
     depthWrite:     true,
+    // Paper is visible from backstage too — the camera's orbit passes
+    // behind the shell mid-transition, and single-sided flats would
+    // vanish into a black beat there.
+    side:           THREE.DoubleSide,
     uniforms: {
       uPainting: { value: null },
       uDepth:    { value: null },


### PR DESCRIPTION
Follow-up to #37/#38, found during the visual verification pass.

The transition orbit passes behind the current painting's shell; single-sided flats backface-cull there, which produced a dead black frame mid-handoff between paintings. Toy-theater flats are visible from backstage — the materials are now `THREE.DoubleSide`, and the backstage sweep keeps the current painting in frame while the next one fades up through the gaps.

Verified locally with headless-Chromium screenshots across two full segments: the black beat is gone, no HTTP errors, hinge gaze and reassembly unaffected.

Note: the three dark paintings' v2 bakes (painting + depth + hinge graph + 3-id manifest) were published to the `art-data` branch — **merging this PR triggers the Pages deploy on main, which will pick that data up and put the paper theater on the live site.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_