### PR TITLE
CI guard: scope the theater bake to the 3 curated paintings

### DIFF
--- a/.github/workflows/process_art.yml
+++ b/.github/workflows/process_art.yml
@@ -94,13 +94,16 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          if [ -z "$HF_TOKEN" ]; then
-            echo "::warning::HF_TOKEN secret is not set — skipping theater bake. Add HF_TOKEN under repo Settings → Secrets → Actions to enable it."
-            exit 0
-          fi
+          # Scoped to the 3 curated paintings while the paper-theater
+          # experience is tuned ("until we get this right with 2-3
+          # paintings, it's not worth baking more"). The v2 bake calls
+          # paid/quota'd image models per painting (photorealize +
+          # depth), so do NOT widen this to the full corpus without an
+          # explicit decision.
           python scripts/theater_baker.py \
             --input  public/assets/ \
-            --output public/data/theater/
+            --output public/data/theater/ \
+            --ids 'PXL_20230527_000631951~2,2023-10-15(38),20231129_043102~2'
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/scripts/theater_baker.py
+++ b/scripts/theater_baker.py
@@ -2,6 +2,9 @@
 """
 theater_baker.py — painting + depth-map baker (schema 2).
 
+CI note: .github/workflows/process_art.yml invokes this with an explicit
+--ids allowlist; widening that list is a cost decision, not a code change.
+
 The paper-theater data model is exactly two textures per painting plus a
 small metadata file. The renderer builds the diorama at runtime from the
 depth texture: a full-painting backdrop plane plus a handful of cutout


### PR DESCRIPTION
Safety follow-up to #37.

**Why this matters now:** the Process Art workflow auto-triggers on any `theater_baker.py` change, and a run from the #37 merge is still sitting in the queue. When it executes, the unscoped bake step would run the new v2 pipeline — photorealize (FLUX img2img) + depth per painting, both paid/quota'd — across all 1,186 images in `public/assets/`.

**What this does:**
- Pins the CI bake invocation to the 3 curated dark paintings via the baker's `--ids` flag, honoring the "until we get this right with 2-3 paintings, it's not worth baking more" scoping. Widening the list is now an explicit decision, documented in the step and the baker docstring.
- Drops the old skip-without-HF_TOKEN early-exit: the v2 baker has its own fallback ladder (Inference API → public Space → depth-on-painting), and 3 images are fine anonymously.
- The docstring touch in `theater_baker.py` is what makes this merge match the workflow's path filter — the new (scoped) run replaces the queued full-corpus run via the workflow's `cancel-in-progress` concurrency group.

**Merging this PR is what neutralizes the queued full-corpus run.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_