### PR TITLE
Center nulls, widen mid-transit fade, randomize start, add FTP deploy workflow

### DIFF
--- a/.github/workflows/deploy-ftp.yml
+++ b/.github/workflows/deploy-ftp.yml
@@ -1,0 +1,88 @@
+name: Deploy to FTP
+
+# Mirror the built site to your own FTP host. Runs on every push to
+# main, and can be fired by hand from the Actions tab.
+#
+# Required repository secrets (Settings → Secrets and variables → Actions):
+#   FTP_SERVER    e.g. ftp.example.com
+#   FTP_USERNAME  your FTP user
+#   FTP_PASSWORD  your FTP password
+# Optional variables (Settings → Secrets and variables → Actions → Variables):
+#   FTP_SERVER_DIR   remote path to mirror into. Defaults to /public_html/.
+#                    If your host serves from a subfolder (e.g. /portfolio/),
+#                    also change `base` in vite.config.js to match, or the
+#                    JS/CSS <script>/<link> tags will 404.
+#   FTP_PROTOCOL     "ftps" (default) or "ftp" if your host doesn't do TLS.
+#
+# The site's baked data lives on the orphan `art-data` branch and is
+# injected into public/data at build time (same pattern as deploy.yml).
+# Without that step the site would render the flat-fallback plane
+# instead of the paper theater.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ftp-deploy
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source (main)
+        uses: actions/checkout@v4
+        with:
+          path: main
+
+      - name: Check out baked data (art-data)
+        uses: actions/checkout@v4
+        with:
+          ref: art-data
+          path: art-data
+        continue-on-error: true
+
+      - name: Stage baked data into public/data
+        run: |
+          if [ -d art-data ] && [ -n "$(ls -A art-data 2>/dev/null | grep -v '^\.git$')" ]; then
+            mkdir -p main/public/data
+            # Mirror everything from art-data except its git metadata.
+            rsync -a --exclude='.git' art-data/ main/public/data/
+            echo "staged $(find main/public/data -type f | wc -l) data files"
+          else
+            echo "::warning::art-data branch is empty or missing — site will use flat fallback for every painting"
+          fi
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: main/package-lock.json
+
+      - name: Install
+        working-directory: main
+        run: npm ci
+
+      - name: Build
+        working-directory: main
+        run: npm run build
+
+      - name: Deploy over FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          username: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          protocol: ${{ vars.FTP_PROTOCOL || 'ftps' }}
+          local-dir: ./main/dist/
+          server-dir: ${{ vars.FTP_SERVER_DIR || '/public_html/' }}
+          # Only touch changed files (state cached remotely by the action).
+          # If your host clears .ftp-deploy-sync-state.json you'll get one
+          # full re-upload; that's harmless.
+          state-name: .ftp-deploy-sync-state.json

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,10 @@ public/data/theater/*.depth.png
 public/data/theater/*.photo.png
 public/data/theater/graph.theater.json
 public/data/theater/_manifest.json
+# And the directory itself when it's a local-dev symlink pointing at an
+# art-data worktree — used for building/serving locally with the deployed
+# corpus in place. Never a real committed entry on source branches.
+/public/data/theater
 
 *.example
 *.local

--- a/src/components/AnamorphicCam.jsx
+++ b/src/components/AnamorphicCam.jsx
@@ -10,26 +10,49 @@ const PAGES_PER_SEGMENT = 4;
 const tmpLook = new THREE.Vector3();
 
 /**
- * The bubbles rule (from the reference video): however the camera moves,
- * it stays pointed at ONE central point — the segment's `focus`, the
- * pareidolia hinge the camera orbits on its nested spheres. Late in the
- * segment the gaze hands off: preferably straight to the NEXT segment's
- * focus (so consecutive orbits share a continuous line of sight),
- * falling back to `endLook` (the destination painting's shell front,
- * dead ahead at the null) while the next segment hasn't been built yet.
+ * The bubbles rule (from the reference video): mid-transit the camera
+ * stays pointed at ONE central point — the segment's `focus`, the
+ * shared patch it orbits on nested spheres. At either NULL, though, the
+ * gaze must be dead-ahead on the current painting so the paper theater
+ * reassembles head-on. The choreography per segment:
+ *
+ *    r ≤ 0.15   look at cur.startLook  (current painting, head-on)
+ *    r ∈ (0.15, 0.35)   blend startLook → focus
+ *    r ∈ (0.35, 0.65)   look at focus  (orbiting the hinge)
+ *    r ∈ (0.65, 0.85)   blend focus → endLook
+ *    r ≥ 0.85   look at cur.endLook  (next painting, head-on)
+ *
+ * Both nulls therefore frame their painting dead centre; only the
+ * middle of the transit routes the gaze through the off-centre hinge.
  */
-function lookTarget(segments, segmentIndex, r) {
-  const cur = segments[segmentIndex];
-  const next = segments[segmentIndex + 1];
-  const from = cur.focus || cur.path[cur.path.length - 1];
-  const to = next?.focus || cur.endLook || cur.path[cur.path.length - 1];
-  const t = THREE.MathUtils.smoothstep(r, 0.6, 0.95);
-  tmpLook.set(
+const tmpA = new THREE.Vector3();
+const tmpB = new THREE.Vector3();
+
+function lerpTo(out, from, to, t) {
+  out.set(
     THREE.MathUtils.lerp(from.x, to.x, t),
     THREE.MathUtils.lerp(from.y, to.y, t),
     THREE.MathUtils.lerp(from.z, to.z, t),
   );
-  return tmpLook;
+  return out;
+}
+
+function lookTarget(segments, segmentIndex, r) {
+  const cur = segments[segmentIndex];
+  const endFallback = cur.path[cur.path.length - 1];
+  const startLook = cur.startLook || cur.path[0];
+  const focus = cur.focus || endFallback;
+  const endLook = cur.endLook || endFallback;
+
+  if (r <= 0.15) return tmpLook.copy(startLook);
+  if (r >= 0.85) return tmpLook.copy(endLook);
+  if (r < 0.35) {
+    return lerpTo(tmpLook, startLook, focus, THREE.MathUtils.smoothstep(r, 0.15, 0.35));
+  }
+  if (r > 0.65) {
+    return lerpTo(tmpLook, focus, endLook, THREE.MathUtils.smoothstep(r, 0.65, 0.85));
+  }
+  return tmpLook.copy(focus);
 }
 
 export default function AnamorphicCam() {

--- a/src/components/AnamorphicCam.jsx
+++ b/src/components/AnamorphicCam.jsx
@@ -25,18 +25,6 @@ const tmpLook = new THREE.Vector3();
  * Both nulls therefore frame their painting dead centre; only the
  * middle of the transit routes the gaze through the off-centre hinge.
  */
-const tmpA = new THREE.Vector3();
-const tmpB = new THREE.Vector3();
-
-function lerpTo(out, from, to, t) {
-  out.set(
-    THREE.MathUtils.lerp(from.x, to.x, t),
-    THREE.MathUtils.lerp(from.y, to.y, t),
-    THREE.MathUtils.lerp(from.z, to.z, t),
-  );
-  return out;
-}
-
 function lookTarget(segments, segmentIndex, r) {
   const cur = segments[segmentIndex];
   const endFallback = cur.path[cur.path.length - 1];
@@ -47,10 +35,10 @@ function lookTarget(segments, segmentIndex, r) {
   if (r <= 0.15) return tmpLook.copy(startLook);
   if (r >= 0.85) return tmpLook.copy(endLook);
   if (r < 0.35) {
-    return lerpTo(tmpLook, startLook, focus, THREE.MathUtils.smoothstep(r, 0.15, 0.35));
+    return tmpLook.lerpVectors(startLook, focus, THREE.MathUtils.smoothstep(r, 0.15, 0.35));
   }
   if (r > 0.65) {
-    return lerpTo(tmpLook, focus, endLook, THREE.MathUtils.smoothstep(r, 0.65, 0.85));
+    return tmpLook.lerpVectors(focus, endLook, THREE.MathUtils.smoothstep(r, 0.65, 0.85));
   }
   return tmpLook.copy(focus);
 }

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -57,12 +57,17 @@ export default function Scene() {
       })
       .catch(() => null);
 
+    // Pick a random starting painting so every visit begins somewhere
+    // different — the corpus is small enough that a deterministic
+    // nodes[0] made repeat visits feel like a fixed lobby.
+    const pickStart = (nodes) => nodes[Math.floor(Math.random() * nodes.length)].id;
+
     loadFromTheater
       .then(theater => {
         if (cancelled) return;
         if (theater && theater.nodes.length > 0) {
           setGraph({ schemaVersion: 5, nodes: theater.nodes, edges: theater.edges });
-          setStartNode(theater.nodes[0].id);
+          setStartNode(pickStart(theater.nodes));
           return;
         }
         console.warn("[Scene] theater manifest missing/empty; falling back to graph.json.");
@@ -73,7 +78,7 @@ export default function Scene() {
             return;
           }
           setGraph({ schemaVersion: 2, nodes: g.nodes, edges: g.edges });
-          setStartNode(g.nodes[0].id);
+          setStartNode(pickStart(g.nodes));
         });
       });
 

--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -19,11 +19,13 @@ const SHELL_DEPTH     = 6.0;
 const SHELL_FRONT     = 11.0;
 
 // Distance envelope: full colour inside FADE_FULL, gone past FADE_GONE.
-// Paintings are 36 units apart, so the next diorama fades up through the
-// current one's cutout gaps while the camera is still inside this shell —
-// that interleaving is the transition.
-const FADE_FULL = 18.0;
-const FADE_GONE = 34.0;
+// Paintings are SEGMENT_LENGTH=36 units apart. At the middle of a
+// transit the camera sits ~18 units from each null; if FADE_FULL is
+// also 18 the current painting hits zero exactly as the next hasn't
+// yet risen, so the frame goes fully black. Widened past half-segment
+// so BOTH dioramas are visible mid-transit and their flats interleave.
+const FADE_FULL = 24.0;
+const FADE_GONE = 44.0;
 
 // When the camera's world z crosses a flat's z, the flat dissolves to
 // black over this many units instead of clipping across the near plane.

--- a/src/store/useStore.jsx
+++ b/src/store/useStore.jsx
@@ -166,8 +166,12 @@ const useStore = create((set, get) => ({
             nextPos[0], nextPos[1],
             nextPos[2] - SHELL_FRONT - SHELL_DEPTH * 0.5);
 
-    // Where the gaze settles at the segment's end: the next painting's
-    // shell front, dead ahead — the head-on reassembly view at the null.
+    // Where the gaze rests at each end of the segment — the CURRENT
+    // painting's shell front (dead ahead from A's null) and the NEXT
+    // painting's shell front (dead ahead from B's null). Head-on
+    // reassembly at both nulls; only the middle of the transit routes
+    // through the off-center hinge patch.
+    const startLook = new THREE.Vector3(current.worldPos[0], current.worldPos[1], currentZ - SHELL_FRONT);
     const endLook = new THREE.Vector3(nextPos[0], nextPos[1], nextPos[2] - SHELL_FRONT);
 
     const dir0 = startPoint.clone().sub(focus).normalize();
@@ -199,6 +203,7 @@ const useStore = create((set, get) => ({
         startId: current.id,
         endId: nextId,
         focus,
+        startLook,
         endLook,
         bank: (Math.random() * 2 - 1) * 0.12,
     };


### PR DESCRIPTION
Four fixes surfaced during a Playwright pass against a build carrying the live `art-data` corpus, plus the FTP deploy workflow you asked for.

## Render fixes

### 1. Nulls were miscentered
`AnamorphicCam.lookTarget` was aimed at the segment's `focus` (the pareidolia hinge — off-center by design) throughout the transit, including at `r=0` and `r=1`. That meant the head-on frame at each null showed the painting shoved into a corner instead of centered. Fix: added `startLook` per segment (dead-ahead of the current painting's shell front, mirroring the existing `endLook`) and reshaped the choreography:

- `r ≤ 0.15` — look at `startLook` (current painting, head-on)
- `r ∈ (0.15, 0.35)` — smoothstep blend to `focus`
- `r ∈ (0.35, 0.65)` — orbiting the hinge (`focus`)
- `r ∈ (0.65, 0.85)` — smoothstep blend to `endLook`
- `r ≥ 0.85` — look at `endLook` (next painting, head-on)

Both nulls now frame their painting dead center; only the middle of the transit routes the gaze through the off-center hinge, which is the "bubbles" reading from the reference video.

### 2. Mid-transitions went pitch black
`TheaterPainting` fade envelope was `FADE_FULL=18`, `FADE_GONE=34` — with `SEGMENT_LENGTH=36`, at `r≈0.5` both paintings are exactly 18 units from the camera, so A's flats fade to zero right as B's haven't started rising. Widened to `FADE_FULL=24`, `FADE_GONE=44` so both dioramas overlap mid-transit and the flat-interleave (that IS the transition) actually happens.

### 3. Random starting painting
`Scene.jsx` was calling `setStartNode(nodes[0].id)` — first manifest entry, deterministic. Every visit began on the same artwork. Now picks uniformly at random.

## Deploy workflow

`.github/workflows/deploy-ftp.yml`: on push to `main` (and manual dispatch), checks out `art-data` into `public/data`, `npm ci` + `npm run build`, then mirrors `dist/` to your FTP host with SamKirkland/FTP-Deploy-Action.

**Add these secrets in Settings → Secrets and variables → Actions:**
- `FTP_SERVER` (e.g. `ftp.example.com`)
- `FTP_USERNAME`
- `FTP_PASSWORD`

**Optional variables** (Settings → Secrets and variables → Actions → *Variables*):
- `FTP_SERVER_DIR` — remote path to mirror into (defaults to `/public_html/`). If your host serves from a subfolder like `/portfolio/`, also change `base` in `vite.config.js` to match or the JS/CSS `<script>`/`<link>` tags will 404.
- `FTP_PROTOCOL` — `ftps` (default) or `ftp` if your host doesn't do TLS.

The `art-data` checkout uses `continue-on-error: true` so a repo without that branch just deploys the flat-fallback build with a warning instead of failing.

## Housekeeping
- `.gitignore` now ignores `public/data/theater` when it's a local-dev symlink (I sometimes symlink it at an `art-data` worktree for local screenshots). Non-symlink deployed contents are already covered by the existing patterns above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_