### PR TITLE
deploy-ftp: default protocol to ftp, bump Node to 22

### DIFF
--- a/.github/workflows/deploy-ftp.yml
+++ b/.github/workflows/deploy-ftp.yml
@@ -12,7 +12,7 @@ name: Deploy to FTP
 #                    If your host serves from a subfolder (e.g. /portfolio/),
 #                    also change `base` in vite.config.js to match, or the
 #                    JS/CSS <script>/<link> tags will 404.
-#   FTP_PROTOCOL     "ftps" (default) or "ftp" if your host doesn't do TLS.
+#   FTP_PROTOCOL     "ftp" (default) or "ftps" if your host supports TLS.
 #
 # The site's baked data lives on the orphan `art-data` branch and is
 # injected into public/data at build time (same pattern as deploy.yml).
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
           cache-dependency-path: main/package-lock.json
 
@@ -79,7 +79,7 @@ jobs:
           server: ${{ secrets.FTP_SERVER }}
           username: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
-          protocol: ${{ vars.FTP_PROTOCOL || 'ftps' }}
+          protocol: ${{ vars.FTP_PROTOCOL || 'ftp' }}
           local-dir: ./main/dist/
           server-dir: ${{ vars.FTP_SERVER_DIR || '/public_html/' }}
           # Only touch changed files (state cached remotely by the action).


### PR DESCRIPTION
## Summary
- The target FTP host doesn't do TLS, so `ftps` was the wrong default. Flip the workflow default to `ftp` (the `FTP_PROTOCOL` repo variable still overrides for anyone whose host does TLS).
- Bump `actions/setup-node` pin from `20` → `22` so the runner stops warning that Node 20 is being deprecated.

## Not addressed here (user side)
The last run also errored with `Input required and not supplied: server`. That means the `FTP_SERVER` repo secret isn't set — no code change fixes that. Set `FTP_SERVER`, `FTP_USERNAME`, and `FTP_PASSWORD` under **Settings → Secrets and variables → Actions → New repository secret** for the deploy step to succeed.

## Test plan
- [ ] Merge, then trigger the workflow manually (**Actions → Deploy to FTP → Run workflow**) once the FTP secrets are set.
- [ ] Confirm the deploy step uses `ftp` protocol and no longer errors on missing inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_