### PR TITLE
Spatial rework: shared origin, mirrored depth+color layers, chroma-ke…

### DIFF
--- a/scripts/theater_baker.py
+++ b/scripts/theater_baker.py
@@ -73,9 +73,10 @@ ImageFile.LOAD_TRUNCATED_IMAGES = True
 # ---- tuning knobs -----------------------------------------------------------
 
 DEFAULT_MAX_SIDE = 768                     # depth Space caps at ~768 long edge
-N_BANDS          = 6                       # AESTHETIC §8.1: ~3-7 flats
-MIN_BAND_COVER   = 0.02                    # merge bands under 2% of pixels
-MIN_BAND_SEP     = 0.08                    # merge bands closer than this in depth
+N_BANDS          = 18                      # depth resolution — dense layer stack
+MIN_BAND_COVER   = 0.008                   # merge bands under 0.8% of pixels
+MIN_BAND_SEP     = 0.025                   # merge bands closer than this in depth
+N_COLOR_BANDS    = 8                       # color-cluster layers (dark→light)
 ACCENT_SAT_FLOOR = 0.18                    # painting reads as desaturated below this
 ACCENT_COUNT     = 2
 N_ACCENT_CLUSTERS = 10
@@ -497,8 +498,18 @@ def bake_image(path: Path, out_dir: Path, max_side: int, force: bool = False) ->
     # -- stage D: bands + metadata ------------------------------------------------
     edges, centers = depth_bands_kmeans(depth)
 
-    _, color_centers = color_clusters(rgb, N_ACCENT_CLUSTERS)
-    accents = pick_accents(color_centers)
+    _, color_centers = color_clusters(rgb, N_COLOR_BANDS)
+    color_centers_norm = [
+        [round(float(c[0]) / 255.0, 4),
+         round(float(c[1]) / 255.0, 4),
+         round(float(c[2]) / 255.0, 4)]
+        for c in color_centers
+    ]
+
+    # Accents (for the overlay's per-painting palette flash) still want a
+    # richer color set, so re-run k-means at the accent count.
+    _, accent_centers = color_clusters(rgb, N_ACCENT_CLUSTERS)
+    accents = pick_accents(accent_centers)
 
     meta = {
         "schema": 2,
@@ -508,6 +519,13 @@ def bake_image(path: Path, out_dir: Path, max_side: int, force: bool = False) ->
             "source": source,
             "file":   out_depth.name,
             "bands":  {"count": len(centers), "edges": edges, "centers": centers},
+        },
+        # Color-cluster centers, dark→light, in normalized [0,1] RGB. The
+        # renderer feeds these into the shader as `uColorCenters` and
+        # assigns each pixel to its nearest cluster on the fly.
+        "color":  {
+            "count":   N_COLOR_BANDS,
+            "centers": color_centers_norm,
         },
     }
     if accents is not None:

--- a/src/components/AnamorphicCam.jsx
+++ b/src/components/AnamorphicCam.jsx
@@ -1,4 +1,3 @@
-import { useRef } from 'react';
 import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useStore } from '../store/useStore';
@@ -46,7 +45,6 @@ function lookTarget(segments, segmentIndex, r) {
 export default function AnamorphicCam() {
   const { camera } = useThree();
   const scroll = useScroll();
-  const isTransitioningRef = useRef(false);
 
   const segments = useStore(state => state.segments);
   const setTransitionProgress = useStore(state => state.setTransitionProgress);
@@ -55,9 +53,14 @@ export default function AnamorphicCam() {
     if (segments.length === 0) return;
 
     const totalPages = scroll.pages;
+    // Total progress can span [0, segments.length]. We clamp to the
+    // already-built range so the user can scroll back into segments they
+    // have already visited (bidirectional navigation) while forward
+    // scroll builds more.
     const totalProgress = (scroll.offset * totalPages) / PAGES_PER_SEGMENT;
-    const segmentIndex = Math.min(Math.floor(totalProgress), segments.length - 1);
-    const r = totalProgress - Math.floor(totalProgress);
+    const clampedTotal = Math.max(0, Math.min(totalProgress, segments.length - 0.001));
+    const segmentIndex = Math.min(Math.floor(clampedTotal), segments.length - 1);
+    const r = clampedTotal - segmentIndex;
 
     const currentSegment = segments[segmentIndex];
     if (!currentSegment) return;
@@ -65,10 +68,6 @@ export default function AnamorphicCam() {
     setTransitionProgress(r);
 
     const curve = new THREE.CatmullRomCurve3(currentSegment.path);
-
-    // Position on the segment's orbit; gaze locked on the segment focus
-    // (see lookTarget). A touch of bank through the middle of the orbit
-    // keeps the sweep from feeling like it's on rails.
     camera.position.copy(curve.getPointAt(r));
     camera.lookAt(lookTarget(segments, segmentIndex, r));
     if (currentSegment.bank) {
@@ -76,19 +75,19 @@ export default function AnamorphicCam() {
     }
 
     // Build ahead early — the gaze handoff at r>0.6 wants the next
-    // segment's focus to already exist.
+    // segment's focus to already exist. Only fires when the user is
+    // actually near the frontier; scrolling backwards never extends.
     if (r > 0.5 && segments.length < segmentIndex + 2) {
       useStore.getState().buildNextSegment();
     }
 
-    if (useStore.getState().currentSegmentIndex !== segmentIndex) {
-      useStore.getState().completeTransition();
-    }
-
-    if (scroll.offset > 0.999 && !isTransitioningRef.current) {
-      isTransitioningRef.current = true;
-      if (scroll.el) scroll.el.scrollTop = 0;
-      setTimeout(() => { isTransitioningRef.current = false; }, 100);
+    // Keep the store's currentSegmentIndex in sync with the scroll —
+    // this is what drives which paintings are mounted in <Scene>. Update
+    // in BOTH directions (forward and backward) so scrolling back
+    // remounts the earlier paintings.
+    const storeIdx = useStore.getState().currentSegmentIndex;
+    if (storeIdx !== segmentIndex) {
+      useStore.getState().backtrackTo(segmentIndex);
     }
   });
 

--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -106,7 +106,7 @@ export default function Scene() {
             <group>
                 {activeClusters
                     .map((cluster, index) => ({ ...cluster, index }))
-                    .filter(c => c.index >= currentSegmentIndex - 1 && c.index <= currentSegmentIndex + 2)
+                    .filter(c => c.index >= currentSegmentIndex - 2 && c.index <= currentSegmentIndex + 2)
                     .map((cluster) => (
                         <TheaterPainting
                             key={`${cluster.id}-${cluster.index}`}

--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -3,36 +3,40 @@ import { useFrame, useThree } from '@react-three/fiber';
 import * as THREE from 'three';
 import { useStore } from '../store/useStore';
 
-// World-height of every painting's central shell, and the depth of the
-// shell from front to back. Each painting occupies a slab of 3D space
-// `PAINTING_HEIGHT × aspect × SHELL_DEPTH`: a full-painting backdrop at
-// the rear plus a handful of cutout flats in front — a paper theater.
-const PAINTING_HEIGHT = 10.0;
-const SHELL_DEPTH     = 6.0;
+// Each painting sits at world (0, 0, 0) with its own rotation. Its layer
+// stack extends along the painting's local Z axis, mirrored across the
+// origin: for every cutout flat at local z = +d there is an identical
+// twin at z = -d. The backdrop plane sits at z = 0. Two families of
+// cutouts stack outward from origin:
+//
+//   depth flats — one per depth band, discarding pixels outside that band
+//   color flats — one per color cluster, discarding pixels outside that cluster
+//
+// Both families are chroma-keyed: pixels darker than CHROMA_L → discard, so
+// the painting's black regions dissolve into the black void behind it.
+//
+// Head-on the front-side flats occlude the origin-plane backdrop and one
+// another to reassemble the painting exactly. Off-axis the flats part
+// with real parallax; as the camera passes through the origin plane, the
+// mirrored back-side layers become the near ones.
+const PAINTING_HEIGHT   = 10.0;
+const SHELL_HALF_DEPTH  = 5.0;      // layers occupy z ∈ [-SHELL_HALF_DEPTH, +SHELL_HALF_DEPTH]
+const NULL_DISTANCE     = 11.0;     // camera radius that reads a painting head-on
+const CHROMA_L          = 0.045;    // luminance below this counts as "black" → discard
 
-// Push the shell ahead of the painting's worldPos so the camera, which
-// arrives at worldPos at each null, sees the painting at a comfortable
-// reading distance instead of plunging into its near face.
-//   front flat at  world z = worldPos.z - SHELL_FRONT
-//   backdrop  at   world z = worldPos.z - SHELL_FRONT - SHELL_DEPTH
-// Chosen so a 10-unit-tall painting at 50° FoV roughly fills the frame.
-const SHELL_FRONT     = 11.0;
-
-// Distance envelope: full colour inside FADE_FULL, gone past FADE_GONE.
-// Paintings are SEGMENT_LENGTH=36 units apart. At the middle of a
-// transit the camera sits ~18 units from each null; if FADE_FULL is
-// also 18 the current painting hits zero exactly as the next hasn't
-// yet risen, so the frame goes fully black. Widened past half-segment
-// so BOTH dioramas are visible mid-transit and their flats interleave.
+// Distance envelope: full colour when the camera is on the painting's
+// null-sphere or inside; fades to black as it drifts far off. Distance is
+// measured from the world origin (paintings share it), so this envelope
+// is really the "how close to any diorama's ideal view" fade — always at
+// least one painting is lit while the camera orbits.
 const FADE_FULL = 24.0;
 const FADE_GONE = 44.0;
 
-// When the camera's world z crosses a flat's z, the flat dissolves to
-// black over this many units instead of clipping across the near plane.
+// Cross-fade when the camera crosses a flat in local z: flat fades to
+// black over this many units instead of clipping the near plane.
 const CROSS_FADE = 1.2;
 
-// The backdrop is slightly oversized so lateral parallax never exposes
-// its frame edge behind the cutout flats.
+// The backdrop is oversized so parallax never exposes its frame edge.
 const BACKDROP_OVERSCAN = 1.08;
 
 
@@ -53,6 +57,7 @@ function fetchTheaterMeta(id) {
 
 // ---- shaders ----------------------------------------------------------------
 
+// Shared vertex passthrough. All flats are unit planes scaled per-mesh.
 const flatVS = /* glsl */ `
 varying vec2 vUv;
 void main() {
@@ -62,50 +67,78 @@ void main() {
 }
 `;
 
-// A cutout flat: sample the painting and the depth map. Pixels whose depth
-// falls outside this flat's band are discarded — the flat is the cut-paper
-// silhouette of one depth stratum. The band threshold is jittered with a
-// small hash noise so the cut edge tears organically instead of aliasing
-// along iso-depth contours. uFade lerps toward black (the void), never
-// toward transparency — flats are opaque cardboard, and real depth-writes
-// keep occlusion honest.
+// Fragment shader for every flat. Behavior varies by three uniforms:
+//   uMode:
+//     0 = backdrop (no cutout, just chroma-key)
+//     1 = depth band cutout
+//     2 = color cluster cutout
+//   uBandMin/Max — depth band edges (mode 1)
+//   uColorIdx + uColorCenters[] — color cluster gate (mode 2)
+//
+// The chroma-key gate runs for every mode: pure-black regions of the
+// painting are discarded so the void shows through.
+//
+// A cheap hash-based tear noise softens the depth-band boundaries into
+// organic torn-paper edges (mode 1 only).
 const flatFS = /* glsl */ `
 precision highp float;
 uniform sampler2D uPainting;
 uniform sampler2D uDepth;
-uniform float uBandMin;    // band edges in [0,1] depth
+uniform float uMode;         // 0 backdrop, 1 depth, 2 color
+uniform float uBandMin;
 uniform float uBandMax;
-uniform float uBackdrop;   // 1.0 = full-bleed backdrop, no discard
-uniform float uFade;       // 0 = black/void, 1 = full colour
+uniform float uColorIdx;
+uniform vec3  uColorCenters[16];
+uniform float uNColorCenters;
+uniform float uFade;
 varying vec2 vUv;
 
 float hash(vec2 p) {
   return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453123);
 }
 
-// Bilinear value noise — smooth enough that the band threshold wanders in
-// organic lobes (paper tears) rather than per-texel speckle.
 float vnoise(vec2 p) {
   vec2 i = floor(p);
   vec2 f = fract(p);
   vec2 u = f * f * (3.0 - 2.0 * f);
   return mix(
-    mix(hash(i),                 hash(i + vec2(1.0, 0.0)), u.x),
+    mix(hash(i),                  hash(i + vec2(1.0, 0.0)), u.x),
     mix(hash(i + vec2(0.0, 1.0)), hash(i + vec2(1.0, 1.0)), u.x),
     u.y);
 }
 
 void main() {
-  if (uBackdrop < 0.5) {
+  vec3 painting = texture2D(uPainting, vUv).rgb;
+
+  // Chroma-key: kill near-black. BT.709 luma; slight uv-noise threshold
+  // so the edges of dark regions tear organically instead of aliasing.
+  float lum = 0.2126 * painting.r + 0.7152 * painting.g + 0.0722 * painting.b;
+  float chromaJit = (vnoise(vUv * 128.0) - 0.5) * 0.015;
+  if (lum + chromaJit < ${CHROMA_L.toFixed(4)}) discard;
+
+  if (uMode > 0.5 && uMode < 1.5) {
+    // Depth band cutout
     float d = texture2D(uDepth, vUv).r;
-    // Torn-paper edge: wander the band threshold with coarse lobes plus a
-    // little fibre-scale fuzz.
     float tear = (vnoise(vUv * 48.0) - 0.5) * 0.05
                + (hash(vUv * 1024.0) - 0.5) * 0.012;
     float dj = d + tear;
     if (dj < uBandMin || dj >= uBandMax) discard;
+  } else if (uMode > 1.5) {
+    // Color cluster cutout — assign this pixel to the nearest cluster
+    // among the first uNColorCenters entries of uColorCenters, then keep
+    // only pixels whose nearest cluster is this flat's uColorIdx.
+    int n = int(uNColorCenters + 0.5);
+    float bestD = 1e6;
+    int best = 0;
+    for (int i = 0; i < 16; i++) {
+      if (i >= n) break;
+      vec3 c = uColorCenters[i];
+      float dd = dot(painting - c, painting - c);
+      if (dd < bestD) { bestD = dd; best = i; }
+    }
+    if (best != int(uColorIdx + 0.5)) discard;
   }
-  vec3 painting = texture2D(uPainting, vUv).rgb;
+
   gl_FragColor = vec4(painting * uFade, 1.0);
 }
 `;
@@ -113,48 +146,84 @@ void main() {
 
 // ---- flat assembly ------------------------------------------------------------
 
-// Build the paper theater from schema-2 metadata: one backdrop (the whole
-// painting, rearmost) + one cutout flat per depth band. Band center depth
-// t (0 = rearmost, 1 = frontmost) maps to
-//   z(t)     = -(SHELL_FRONT + SHELL_DEPTH * (1 - t))
-//   persp(t) =  (SHELL_FRONT + SHELL_DEPTH * (1 - t)) / SHELL_FRONT
-// The perspective compensation makes every flat subtend exactly the same
-// view from the null — head-on the flats reassemble into the original
-// painting over the backdrop; any camera offset parts them into coherent
-// physical parallax.
-function buildFlats(metadata) {
-  const bands = metadata?.depth?.bands;
-  if (!bands || !Array.isArray(bands.edges) || !Array.isArray(bands.centers)) return [];
-  const aspect = (metadata.src?.width || 1) / (metadata.src?.height || 1);
+// Given depth band centers and color center count, build the full mirrored
+// stack of flat descriptors. Local z = 0 is the painting's origin (shared
+// world origin); positive z is the "front" half (camera-facing when the
+// camera is on the +Z side of the group's local frame), negative z is the
+// mirrored back half.
+function buildFlats(meta) {
+  const flats = [];
+  const aspect = (meta?.src?.width || 1) / (meta?.src?.height || 1);
   const planeWidth  = PAINTING_HEIGHT * aspect;
   const planeHeight = PAINTING_HEIGHT;
 
-  const depthAt = (t) => SHELL_FRONT + SHELL_DEPTH * (1 - t);
+  // Perspective compensation: at each null, camera sits at viewDir *
+  // NULL_DISTANCE along the painting's local +Z axis. A flat at local z
+  // is (NULL_DISTANCE - z) units from the camera; scaling it by that
+  // ratio makes every flat subtend the same visual angle so they
+  // reassemble into the painting at the null. Off-axis, the disparate
+  // scales are what create the "layers exploded outward" look.
+  const persp = (z) => (NULL_DISTANCE - z) / NULL_DISTANCE;
 
-  const flats = [{
+  // Backdrop — the whole painting at the origin plane. Slightly overscaled
+  // so lateral parallax never exposes its frame edge behind the cutouts.
+  flats.push({
     kind: 'backdrop',
-    bandMin: 0, bandMax: 1,
-    z: -depthAt(0),
-    persp: depthAt(0) / SHELL_FRONT,
-    overscan: BACKDROP_OVERSCAN,
+    mode: 0,
+    z: 0,
+    scale: BACKDROP_OVERSCAN * persp(0),
     planeWidth, planeHeight,
-  }];
+    bandMin: 0, bandMax: 1,
+    colorIdx: -1,
+  });
 
-  for (let i = 0; i < bands.centers.length; i++) {
-    // The rearmost band is already carried by the backdrop; a cutout copy
-    // of it at the same depth would only z-fight.
-    if (i === 0) continue;
-    const t = bands.centers[i];
-    flats.push({
-      kind: 'flat',
-      bandMin: bands.edges[i],
-      bandMax: bands.edges[i + 1],
-      z: -depthAt(t),
-      persp: depthAt(t) / SHELL_FRONT,
-      overscan: 1.0,
-      planeWidth, planeHeight,
-    });
+  const depthCenters = meta?.depth?.bands?.centers || [];
+  const depthEdges   = meta?.depth?.bands?.edges   || [];
+
+  // Depth flats: spread across the front-half of the shell, then mirrored
+  // to the back. Skip the rearmost band — it's already carried by the
+  // backdrop and a duplicate at z = 0 would z-fight.
+  const nDepth = depthCenters.length;
+  for (let i = 1; i < nDepth; i++) {
+    const t = depthCenters[i]; // 0..1
+    // Map band center depth (0 = far / 1 = near) onto [+eps, +SHELL_HALF_DEPTH].
+    const zFront = SHELL_HALF_DEPTH * ((i) / Math.max(1, nDepth - 1));
+    for (const sign of [+1, -1]) {
+      const z = sign * zFront;
+      flats.push({
+        kind: 'depth',
+        mode: 1,
+        z,
+        scale: persp(z),
+        planeWidth, planeHeight,
+        bandMin: depthEdges[i],
+        bandMax: depthEdges[i + 1],
+        colorIdx: -1,
+      });
+    }
   }
+
+  const colorCenters = meta?.color?.centers || [];
+  const nColor = colorCenters.length;
+  // Color flats: interleave with depth on a different offset so a given z
+  // isn't shared with a depth flat (they'd z-fight when both survive).
+  // Front half again, mirrored to back.
+  for (let i = 0; i < nColor; i++) {
+    const zFront = SHELL_HALF_DEPTH * ((i + 0.5) / nColor) * 0.85 + 0.15;
+    for (const sign of [+1, -1]) {
+      const z = sign * zFront;
+      flats.push({
+        kind: 'color',
+        mode: 2,
+        z,
+        scale: persp(z),
+        planeWidth, planeHeight,
+        bandMin: 0, bandMax: 1,
+        colorIdx: i,
+      });
+    }
+  }
+
   return flats;
 }
 
@@ -173,14 +242,8 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     let cancelled = false;
     fetchTheaterMeta(id).then(json => {
       if (cancelled) return;
-      // Only schema-2 metadata drives the layered shell; anything else
-      // (legacy v1 json, missing bake) drops to the flat fallback below.
       const usable = json && json.schema === 2 && json.depth?.bands ? json : null;
       setMeta(usable);
-      // Flat fallback: when the theater bake hasn't run for this id, render
-      // the original asset image as a single textured plane instead of the
-      // layered shell. Looks like the legacy gallery — no parallax — but
-      // the page isn't blank.
       if (!usable && image) {
         const loader = new THREE.TextureLoader();
         loader.load(
@@ -193,7 +256,7 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
             setFlatTex({ texture: tex, aspect: w / h, width: w, height: h });
           },
           undefined,
-          () => { /* image missing — render nothing for this id */ },
+          () => { },
         );
       }
     });
@@ -211,10 +274,21 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
 
   const flats = useMemo(() => meta ? buildFlats(meta) : [], [meta]);
 
-  // Calculate dynamic scale to fit the painting into the screen at SHELL_FRONT.
-  // Same math regardless of whether the layered shell or the flat fallback is
-  // rendering — only the source of the aspect ratio differs (theater.json vs.
-  // the raw asset image dimensions).
+  // Color centers packed into a fixed-length array (matches shader
+  // `uColorCenters[16]` uniform). Extra slots zero-padded.
+  const colorCentersUniform = useMemo(() => {
+    const arr = Array.from({ length: 16 }, () => new THREE.Vector3());
+    const centers = meta?.color?.centers || [];
+    for (let i = 0; i < Math.min(centers.length, 16); i++) {
+      arr[i].set(centers[i][0], centers[i][1], centers[i][2]);
+    }
+    return arr;
+  }, [meta]);
+  const nColorCenters = meta?.color?.centers?.length || 0;
+
+  // Dynamic scale so a painting at NULL_DISTANCE fills the frame. Camera
+  // approaches from world origin along the painting's local +Z axis (after
+  // rotation), so head-on distance is exactly NULL_DISTANCE.
   const { size, camera } = useThree();
   const fitScale = useMemo(() => {
     let paintingWidth, paintingHeight;
@@ -227,9 +301,8 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     } else {
       return 1.0;
     }
-
     const vFov = THREE.MathUtils.degToRad(camera.fov);
-    const visibleHeight = 2.0 * SHELL_FRONT * Math.tan(vFov / 2.0);
+    const visibleHeight = 2.0 * NULL_DISTANCE * Math.tan(vFov / 2.0);
     const visibleWidth  = visibleHeight * (size.width / size.height);
     const widthScale  = (visibleWidth  * 0.85) / paintingWidth;
     const heightScale = (visibleHeight * 0.90) / paintingHeight;
@@ -238,26 +311,24 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
 
   const planeGeom = useMemo(() => new THREE.PlaneGeometry(1, 1), []);
 
-  // One material per flat: opaque, depth-writing paper. Texture uniforms
-  // point at the shared painting/depth textures once those load.
   const flatMaterials = useMemo(() => flats.map(flat => new THREE.ShaderMaterial({
     vertexShader:   flatVS,
     fragmentShader: flatFS,
     transparent:    false,
     depthWrite:     true,
-    // Paper is visible from backstage too — the camera's orbit passes
-    // behind the shell mid-transition, and single-sided flats would
-    // vanish into a black beat there.
     side:           THREE.DoubleSide,
     uniforms: {
-      uPainting: { value: null },
-      uDepth:    { value: null },
-      uBandMin:  { value: flat.bandMin },
-      uBandMax:  { value: flat.bandMax },
-      uBackdrop: { value: flat.kind === 'backdrop' ? 1 : 0 },
-      uFade:     { value: 0 },
+      uPainting:      { value: null },
+      uDepth:         { value: null },
+      uMode:          { value: flat.mode },
+      uBandMin:       { value: flat.bandMin },
+      uBandMax:       { value: flat.bandMax },
+      uColorIdx:      { value: flat.colorIdx },
+      uColorCenters:  { value: colorCentersUniform },
+      uNColorCenters: { value: nColorCenters },
+      uFade:          { value: 0 },
     },
-  })), [flats]);
+  })), [flats, colorCentersUniform, nColorCenters]);
 
   // Load painting + depth textures once meta is known. Pass them into
   // every flat's material.
@@ -275,16 +346,11 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
       if (cancelled) return;
       painting.colorSpace = THREE.SRGBColorSpace;
       painting.anisotropy = 4;
-      // Depth is data, not colour — keep it linear. (Browsers decode the
-      // 16-bit PNG to 8 bits per channel; 256 depth levels is far more
-      // than the ~6 bands need.)
       depth.colorSpace = THREE.NoColorSpace;
       depth.generateMipmaps = false;
       depth.minFilter = THREE.LinearFilter;
       setTextures({ painting, depth });
-    }).catch(() => {
-      // Texture missing — keep the flats around but they'll render nothing.
-    });
+    }).catch(() => { });
     return () => { cancelled = true; };
   }, [id, meta]);
 
@@ -296,9 +362,6 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     }
   }, [textures, flatMaterials]);
 
-  // Push the active painting's source resolution to the store so the overlay
-  // stays coherent. Works for both modes: prefer the theater metadata's src
-  // dims, fall back to the flat texture's natural dims.
   useEffect(() => {
     const isActiveSegment =
       mySegmentIndex === currentSegmentIndex ||
@@ -311,9 +374,6 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     }
   }, [mySegmentIndex, currentSegmentIndex, meta, flatTex, setCurrentResolution]);
 
-  // Dispose per-painting resources when the component unmounts or the id
-  // swaps. planeGeom is tied to the component lifetime; textures + flat
-  // materials regenerate per id.
   useEffect(() => () => {
     if (textures) {
       textures.painting.dispose();
@@ -333,8 +393,6 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     if (flatTex?.texture) flatTex.texture.dispose();
   }, [flatTex]);
 
-  // Shared material for the flat fallback. Created once and updated per-frame
-  // so it picks up the same distance fade as the layered shell.
   const fallbackMaterial = useMemo(
     () => new THREE.MeshBasicMaterial({ toneMapped: false, side: THREE.DoubleSide }),
     [],
@@ -345,37 +403,46 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     fallbackMaterial.needsUpdate = true;
   }, [flatTex, fallbackMaterial]);
 
-  // Camera distance → fade envelope, plus the fly-through dissolve: a flat
-  // the camera is about to cross fades to black over CROSS_FADE units so
-  // the shell can be scrubbed through like theater flats, never clipped.
+  // Distance envelope + fly-through cross-fade. Distance measured from
+  // the painting's world origin (which for the new spatial model is
+  // world (0,0,0) for every painting, so this is really the camera's
+  // distance from the shared centre point).
+  //
+  // Cross-fade: when the camera is close (in the group's local frame) to
+  // one of a flat's local-z faces, dissolve that flat so it doesn't
+  // clip the near plane as the camera passes through.
+  const groupRef = useRef(null);
+  const localCamPos = useMemo(() => new THREE.Vector3(), []);
   useFrame(() => {
-    if (!position) return;
+    if (!position || !groupRef.current) return;
     const v = tmpVec.current;
     v.set(position[0] || 0, position[1] || 0, position[2] || 0);
     const dist = camera.position.distanceTo(v);
     const fade = 1.0 - THREE.MathUtils.smoothstep(dist, FADE_FULL, FADE_GONE);
 
+    // Camera position in the painting's local frame (undoes the group's
+    // rotation and position). Cross-fade uses the local z.
+    groupRef.current.worldToLocal(localCamPos.copy(camera.position));
+
     for (let i = 0; i < flatMaterials.length; i++) {
-      const flatWorldZ = v.z + flats[i].z;
-      const cross = Math.min(
-        Math.abs(camera.position.z - flatWorldZ) / CROSS_FADE, 1.0);
+      const F = flats[i];
+      const cross = F.kind === 'backdrop'
+        ? 1.0
+        : Math.min(Math.abs(localCamPos.z - F.z) / CROSS_FADE, 1.0);
       flatMaterials[i].uniforms.uFade.value = fade * cross;
     }
-    // Fallback plane: same envelope, applied as a colour dim so it stays
-    // opaque too.
     fallbackMaterial.color.setScalar(fade);
   });
 
-  // Flat fallback render — single textured plane at the shell-front depth.
   if (!meta && flatTex) {
     const fw = PAINTING_HEIGHT * flatTex.aspect * fitScale;
     const fh = PAINTING_HEIGHT * fitScale;
     return (
-      <group position={position} rotation={rotEuler}>
+      <group ref={groupRef} position={position} rotation={rotEuler}>
         <mesh
           geometry={planeGeom}
           material={fallbackMaterial}
-          position={[0, 0, -SHELL_FRONT]}
+          position={[0, 0, 0]}
           scale={[fw, fh, 1]}
         />
       </group>
@@ -385,7 +452,7 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
   if (!meta || flats.length === 0 || flatMaterials.length === 0) return null;
 
   return (
-    <group position={position} rotation={rotEuler}>
+    <group ref={groupRef} position={position} rotation={rotEuler}>
       {flats.map((F, i) => (
         <mesh
           key={i}
@@ -393,8 +460,8 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
           material={flatMaterials[i]}
           position={[0, 0, F.z]}
           scale={[
-            F.planeWidth  * fitScale * F.persp * F.overscan,
-            F.planeHeight * fitScale * F.persp * F.overscan,
+            F.planeWidth  * fitScale * F.scale,
+            F.planeHeight * fitScale * F.scale,
             1,
           ]}
         />

--- a/src/store/useStore.jsx
+++ b/src/store/useStore.jsx
@@ -1,49 +1,97 @@
 import { create } from 'zustand';
 import * as THREE from 'three';
 
-// Mirror of TheaterPainting.jsx's shell geometry (see comments there).
-// The hinge focus sits on the shell, so the walk generator needs these.
-const SHELL_FRONT = 11.0;
-const SHELL_DEPTH = 6.0;
-const PAINTING_HEIGHT = 10.0;
+// Camera radius that reads a painting head-on. Matches TheaterPainting.jsx
+// NULL_DISTANCE — both must agree so the null-sphere sits on the shell.
+const NULL_DISTANCE = 11.0;
 
-// Convert a normalized painting uv (u right, v down) to the painting's
-// local xy. Nominal painting height is used (the renderer's viewport
-// fitScale, typically ~0.9, is not known here — hinge placement tolerates
-// the few-percent error; the camera dive hides the rest).
-function uvToLocal(uv, aspect) {
-  return {
-    x: (uv[0] - 0.5) * PAINTING_HEIGHT * aspect,
-    y: (0.5 - uv[1]) * PAINTING_HEIGHT,
-  };
+// The camera never gets closer to origin than this during the dive
+// through the shared centre — deep enough to be "inside all the paintings
+// at once", far enough not to end up beyond every flat.
+const DIVE_RADIUS   = 2.5;
+
+// FNV-1a-ish deterministic hash of a string — used to give each painting
+// a stable per-id rotation + viewing direction across reloads.
+function hashStr(s) {
+  let h = 2166136261 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619) >>> 0;
+  }
+  return h;
+}
+
+// Deterministic pseudorandom in [0, 1) seeded by a hash + salt.
+function rand01(hash, salt) {
+  const x = Math.imul(hash ^ salt, 2654435761) >>> 0;
+  return (x >>> 0) / 4294967296;
+}
+
+// Distribute painting viewing directions on a sphere: for each painting
+// id, pick a stable point on S^2 (Fibonacci-style via the golden angle
+// applied to a per-id azimuth, plus a per-id polar). Guarantees adjacent
+// paintings on the walker aren't accidentally colinear.
+function viewDirForId(id) {
+  const h = hashStr(id || 'anon');
+  const phi = rand01(h, 0x9e3779b9) * Math.PI * 2;
+  // Bias polar angle away from the poles so all paintings sit near the
+  // equator — camera can then move sideways without ever pointing at the
+  // sky. Range roughly [40°, 140°] from +Y.
+  const cosTheta = (rand01(h, 0x85ebca6b) - 0.5) * 1.4;    // ~[-0.7, +0.7]
+  const sinTheta = Math.sqrt(Math.max(0, 1 - cosTheta * cosTheta));
+  return new THREE.Vector3(
+    sinTheta * Math.cos(phi),
+    cosTheta,
+    sinTheta * Math.sin(phi),
+  );
+}
+
+// Given a viewing direction, build the euler rotation (deg) that makes
+// a painting sitting at origin face that direction — i.e. its local +Z
+// axis points TOWARD viewDir (so a camera sitting at viewDir·NULL sees
+// the painting head-on). Roll is fixed to 0 (the painting's local +Y
+// stays "as up as possible") plus a tiny per-id twist so consecutive
+// paintings don't feel co-rotated.
+function rotationForViewDir(viewDir, id) {
+  const q = new THREE.Quaternion().setFromUnitVectors(
+    new THREE.Vector3(0, 0, 1), viewDir.clone().normalize());
+  const roll = (rand01(hashStr(id || 'anon'), 0xdeadbeef) - 0.5) * 0.6;
+  q.multiply(new THREE.Quaternion().setFromAxisAngle(
+    new THREE.Vector3(0, 0, 1), roll));
+  const e = new THREE.Euler().setFromQuaternion(q);
+  return [
+    THREE.MathUtils.radToDeg(e.x),
+    THREE.MathUtils.radToDeg(e.y),
+    THREE.MathUtils.radToDeg(e.z),
+  ];
 }
 
 const useStore = create((set, get) => ({
   // --- STATE ---
-  nodes: [],           
-  edges: [],           
-  
-  activeClusters: [],  // [{ id, worldPos, anchorId, rotSway }]
-  segments: [],        // [{ path, startId, endId }]
-  history: [],         // Not strictly needed for forward scroll, but kept for logic
-  
-  currentNodeId: null, 
+  nodes: [],
+  edges: [],
+
+  activeClusters: [],  // [{ id, worldPos, rotSway, viewDir, image }]
+  segments: [],        // [{ path, startId, endId, focus, startLook, endLook, bank }]
+  history: [],
+
+  currentNodeId: null,
   currentShardCount: 0,
   currentResolution: [1000, 1000],
-  
+
   currentSegmentIndex: 0,
-  transitionProgress: 0, 
+  transitionProgress: 0,
   isTransitioning: false,
-  
+
   // UI State
   showMenu: false,
 
   // --- ACTIONS ---
   setGraph: (graphData) => {
     if (!graphData) return;
-    set({ 
+    set({
       nodes: Array.isArray(graphData.nodes) ? graphData.nodes : [],
-      edges: Array.isArray(graphData.edges) ? graphData.edges : []
+      edges: Array.isArray(graphData.edges) ? graphData.edges : [],
     });
   },
 
@@ -51,12 +99,19 @@ const useStore = create((set, get) => ({
     console.log("[Store] Starting at:", id);
     const { nodes } = get();
     const node = nodes.find(n => n.id === id);
-    const firstCluster = { id, worldPos: [0, 0, 0], image: node?.image };
+    const viewDir = viewDirForId(id);
+    const firstCluster = {
+      id,
+      worldPos: [0, 0, 0],                    // all paintings share origin
+      rotSway: rotationForViewDir(viewDir, id),
+      viewDir,
+      image: node?.image,
+    };
     set({
-        activeClusters: [firstCluster],
-        currentNodeId: id,
-        segments: [],
-        currentSegmentIndex: 0
+      activeClusters: [firstCluster],
+      currentNodeId: id,
+      segments: [],
+      currentSegmentIndex: 0,
     });
     get().buildNextSegment();
   },
@@ -64,192 +119,141 @@ const useStore = create((set, get) => ({
   setCurrentResolution: (res) => set({ currentResolution: res }),
   setCurrentShardCount: (count) => set({ currentShardCount: count }),
 
-  // Build the next step in the infinite void (Append mode)
+  // Build the next step of the walk. All paintings sit at world origin
+  // (rotated differently), so a segment is a camera path on the sphere
+  // of radius NULL_DISTANCE that leaves painting A's ideal viewing point,
+  // dives through the shared centre, and arrives at painting B's ideal
+  // viewing point.
   buildNextSegment: () => {
     const { nodes, edges, activeClusters, segments } = get();
     if (activeClusters.length === 0) return;
 
-    // The segment originates from the LAST cluster in the list
     const current = activeClusters[activeClusters.length - 1];
-    // Distance between consecutive paintings' nulls. The painting shell
-    // is ~15 units deep at its viewing distance, so SEGMENT_LENGTH must
-    // be quite a bit larger than that for the camera to have real
-    // empty-space transit time between paintings instead of plunging
-    // straight from one near-face into the next.
-    const SEGMENT_LENGTH = 36.0;
 
-    const currentZ = current.worldPos[2];
-
-    // 1. Pick next node — weighted by pareidolia edge strength so paintings
-    //    that share more marks with the current one are preferred. Fall back
-    //    to a uniform random other-node if there are no edges.
+    // 1. Pick next node — weighted by pareidolia edge strength if
+    //    available; otherwise a uniform random non-self.
     const candidates = edges.filter(e => e.source === current.id);
     let edge;
     if (candidates.length > 0) {
-        const totalW = candidates.reduce((s, e) => s + (e.weight || 1), 0);
-        let r = Math.random() * totalW;
-        edge = candidates[candidates.length - 1];
-        for (const e of candidates) {
-            r -= (e.weight || 1);
-            if (r <= 0) { edge = e; break; }
-        }
+      const totalW = candidates.reduce((s, e) => s + (e.weight || 1), 0);
+      let r = Math.random() * totalW;
+      edge = candidates[candidates.length - 1];
+      for (const e of candidates) {
+        r -= (e.weight || 1);
+        if (r <= 0) { edge = e; break; }
+      }
     } else {
-        const others = nodes.filter(n => n.id !== current.id);
-        const randomTarget = others[Math.floor(Math.random() * others.length)].id;
-        edge = { target: randomTarget };
+      const others = nodes.filter(n => n.id !== current.id);
+      if (others.length === 0) return;
+      const randomTarget = others[Math.floor(Math.random() * others.length)].id;
+      edge = { target: randomTarget };
     }
 
     const nextId = edge.target;
-    const currentNode = nodes.find(n => n.id === current.id);
     const nextNode = nodes.find(n => n.id === nextId);
-
-    // 2. The pareidolia hinge. The chosen edge carries the shared patch:
-    //    s_uv in painting A, t_uv in painting B — a region that reads as
-    //    part of BOTH paintings' subjects at the same time. Painting B is
-    //    placed so its t_uv point sits at the same world xy as A's s_uv
-    //    point; the camera then orbits that point (below) while A's flats
-    //    give way to B's — the viewer never sees a cut.
-    const aAspect = (currentNode?.width && currentNode?.height)
-        ? currentNode.width / currentNode.height : 1.0;
-    const bAspect = (nextNode?.width && nextNode?.height)
-        ? nextNode.width / nextNode.height : 1.0;
-
-    let hingeLocal = null;   // hinge in A's local xy
-    let nextPos;
-    if (Array.isArray(edge.s_uv) && Array.isArray(edge.t_uv)) {
-        const sL = uvToLocal(edge.s_uv, aAspect);
-        const tL = uvToLocal(edge.t_uv, bAspect);
-        hingeLocal = sL;
-        nextPos = [
-            current.worldPos[0] + sL.x - tL.x,
-            current.worldPos[1] + sL.y - tL.y,
-            currentZ - SEGMENT_LENGTH,
-        ];
-    } else {
-        nextPos = [
-            current.worldPos[0],
-            current.worldPos[1],
-            currentZ - SEGMENT_LENGTH,
-        ];
-    }
-
-    // Paintings stay axis-aligned; all parallax and the fulcrum effect
-    // come from the camera's own movement (AESTHETIC §5 invariant).
-    const rotSway = [0, 0, 0];
+    const nextViewDir = viewDirForId(nextId);
 
     const nextCluster = {
-        id: nextId,
-        worldPos: nextPos,
-        anchorId: undefined,
-        rotSway,
-        image: nextNode?.image,
+      id: nextId,
+      worldPos: [0, 0, 0],
+      rotSway: rotationForViewDir(nextViewDir, nextId),
+      viewDir: nextViewDir,
+      image: nextNode?.image,
     };
 
-    // 3. Camera path — the bubbles. The reference video's camera always
-    //    points at one central point while it moves, as if traveling the
-    //    surfaces of nested spheres that share a core. Here the core is
-    //    the hinge (or, hinge-less, the next painting's shell center):
-    //    the camera leaves A's null on a wide sphere, dives to a tight
-    //    one — swinging AROUND the focus at close radius, through A's
-    //    parted flats — then climbs back out to B's null. Look direction
-    //    is handled in AnamorphicCam: locked on `focus`, handed off to
-    //    the next core late in the segment.
-    const startPoint = new THREE.Vector3(current.worldPos[0], current.worldPos[1], currentZ);
-    const endPoint = new THREE.Vector3(nextPos[0], nextPos[1], nextPos[2]);
+    // 2. Camera path.
+    //    Start on A's null-sphere point (viewDir_A × NULL_DISTANCE),
+    //    dive inward past origin (an anti-podal excursion), then
+    //    climb out to B's null-sphere point. The focus is the shared
+    //    origin — same "bubbles" choreography as before, only the
+    //    focus is now a single fixed point rather than a per-segment
+    //    hinge.
+    const startPoint = current.viewDir.clone().multiplyScalar(NULL_DISTANCE);
+    const endPoint   = nextViewDir.clone().multiplyScalar(NULL_DISTANCE);
+    const focus      = new THREE.Vector3(0, 0, 0);
 
-    const focus = hingeLocal
-        ? new THREE.Vector3(
-            current.worldPos[0] + hingeLocal.x,
-            current.worldPos[1] + hingeLocal.y,
-            currentZ - SHELL_FRONT - SHELL_DEPTH * 0.5)
-        : new THREE.Vector3(
-            nextPos[0], nextPos[1],
-            nextPos[2] - SHELL_FRONT - SHELL_DEPTH * 0.5);
+    // Where the gaze rests at each end — dead ahead of each painting.
+    // For paintings at origin facing viewDir, "dead ahead of the null"
+    // simply means the origin itself; but to keep the reassembly
+    // symmetric with the previous choreography we look at origin.
+    const startLook = focus.clone();
+    const endLook   = focus.clone();
 
-    // Where the gaze rests at each end of the segment — the CURRENT
-    // painting's shell front (dead ahead from A's null) and the NEXT
-    // painting's shell front (dead ahead from B's null). Head-on
-    // reassembly at both nulls; only the middle of the transit routes
-    // through the off-center hinge patch.
-    const startLook = new THREE.Vector3(current.worldPos[0], current.worldPos[1], currentZ - SHELL_FRONT);
-    const endLook = new THREE.Vector3(nextPos[0], nextPos[1], nextPos[2] - SHELL_FRONT);
+    const dir0 = startPoint.clone().normalize();
+    const dir1 = endPoint.clone().normalize();
 
-    const dir0 = startPoint.clone().sub(focus).normalize();
-    const dir1 = endPoint.clone().sub(focus).normalize();
-    const R0 = startPoint.distanceTo(focus);
-    const R1 = endPoint.distanceTo(focus);
-    // The tight inner bubble: close enough that A's flats part around the
-    // camera, far enough that the hinge patch still fills the frame.
-    const Rmin = THREE.MathUtils.clamp(Math.min(R0, R1) * 0.35, 4.0, 8.0);
-
-    // Lateral sweep direction (horizontal-biased — stage flats read
-    // sideways), breaking the front-to-back degeneracy of dir0 → dir1.
-    const sweepAngle = Math.random() * Math.PI * 2;
-    const sweep = new THREE.Vector3(
-        Math.cos(sweepAngle), Math.sin(sweepAngle) * 0.4, 0).normalize();
+    // Break the front-to-back degeneracy of dir0 → dir1 with a lateral
+    // sweep vector (perpendicular to the average of the two).
+    const midDir = dir0.clone().add(dir1).normalize();
+    const worldUp = new THREE.Vector3(0, 1, 0);
+    const sweepBase = new THREE.Vector3().crossVectors(midDir, worldUp);
+    if (sweepBase.lengthSq() < 1e-4) sweepBase.set(1, 0, 0);
+    sweepBase.normalize();
+    const sweepSign = Math.random() < 0.5 ? -1 : 1;
+    const sweep = sweepBase.multiplyScalar(sweepSign);
 
     const orbitPoint = (t) => {
-        const dir = dir0.clone().lerp(dir1, t)
-            .addScaledVector(sweep, Math.sin(Math.PI * t) * 0.9)
-            .normalize();
-        const rOut = t < 0.5
-            ? THREE.MathUtils.lerp(R0, Rmin, THREE.MathUtils.smoothstep(t, 0, 0.5))
-            : THREE.MathUtils.lerp(Rmin, R1, THREE.MathUtils.smoothstep(t, 0.5, 1));
-        return focus.clone().addScaledVector(dir, rOut);
+      // Slerp-ish blend of dir0 → dir1 with a sideways bulge.
+      const dir = dir0.clone().lerp(dir1, t)
+        .addScaledVector(sweep, Math.sin(Math.PI * t) * 0.9)
+        .normalize();
+      // Radius shrinks past NULL toward DIVE at t=0.5, then back out.
+      const rOut = t < 0.5
+        ? THREE.MathUtils.lerp(NULL_DISTANCE, DIVE_RADIUS,
+            THREE.MathUtils.smoothstep(t, 0, 0.5))
+        : THREE.MathUtils.lerp(DIVE_RADIUS, NULL_DISTANCE,
+            THREE.MathUtils.smoothstep(t, 0.5, 1));
+      return dir.multiplyScalar(rOut);
     };
 
     const newSegment = {
-        path: [startPoint, orbitPoint(0.3), orbitPoint(0.5), orbitPoint(0.7), endPoint],
-        startId: current.id,
-        endId: nextId,
-        focus,
-        startLook,
-        endLook,
-        bank: (Math.random() * 2 - 1) * 0.12,
+      path: [startPoint, orbitPoint(0.3), orbitPoint(0.5),
+             orbitPoint(0.7), endPoint],
+      startId: current.id,
+      endId: nextId,
+      focus,
+      startLook,
+      endLook,
+      bank: (Math.random() * 2 - 1) * 0.12,
     };
 
-    set({ 
-        activeClusters: [...activeClusters, nextCluster],
-        segments: [...segments, newSegment]
+    set({
+      activeClusters: [...activeClusters, nextCluster],
+      segments: [...segments, newSegment],
     });
-    
+
     console.log(`[Store] Segment ${segments.length} Appended: ${current.id} -> ${nextId}`);
   },
 
   completeTransition: () => {
-    // This now just cleans up far-away segments or prepares for the next
     const { segments, currentSegmentIndex } = get();
     if (currentSegmentIndex < segments.length - 1) {
-        set({ currentSegmentIndex: currentSegmentIndex + 1 });
+      set({ currentSegmentIndex: currentSegmentIndex + 1 });
     }
-    // We can verify if we need to build more
     if (segments.length < currentSegmentIndex + 3) {
-        get().buildNextSegment();
+      get().buildNextSegment();
     }
   },
 
-  goBackward: () => {
-    const { history } = get();
-    if (history.length === 0) return false;
-
-    // Pop the last state from history
-    const lastState = history[history.length - 1];
-    const remainingHistory = history.slice(0, -1);
-
-    set({
-        activeClusters: lastState.activeClusters,
-        currentPath: lastState.currentPath,
-        history: remainingHistory,
-        currentNodeId: lastState.activeClusters[lastState.activeClusters.length - 1].id,
-        transitionProgress: 1.0, // Start at the end of the previous segment
-        isTransitioning: false
-    });
-    
-    console.log("[Store] Navigating Backward. History depth:", remainingHistory.length);
-    return true;
+  // Scrolling BACKWARD past a segment boundary is a legitimate operation
+  // now — the user can revisit prior segments by scrolling up. The
+  // scroll offset is the source of truth for segmentIndex, so we just
+  // let AnamorphicCam re-index; there's no state to unwind here beyond
+  // updating currentSegmentIndex.
+  backtrackTo: (segmentIndex) => {
+    if (segmentIndex < 0) return;
+    const { segments } = get();
+    if (segmentIndex >= segments.length) return;
+    set({ currentSegmentIndex: segmentIndex });
   },
 
-  setTransitionProgress: (val) => set({ transitionProgress: val, isTransitioning: val > 0.01 && val < 0.99 }),
+  // Legacy — kept as a no-op so any external caller doesn't crash.
+  goBackward: () => false,
+
+  setTransitionProgress: (val) => set({
+    transitionProgress: val,
+    isTransitioning: val > 0.01 && val < 0.99,
+  }),
   toggleMenu: () => set(state => ({ showMenu: !state.showMenu })),
 }));
 


### PR DESCRIPTION
…y black, bidirectional scroll

theater_baker.py: N_BANDS 6 -> 18 (3x depth resolution). Emits color cluster centers (8) alongside depth bands so the renderer can build a color-cluster layer stack in-shader without a mask texture.

TheaterPainting.jsx: rewrote around a symmetric shell mirrored across each painting's local origin. One backdrop + N depth cutout flats + M color cutout flats, EACH mirrored to a twin behind the origin plane. Fragment shader modes 0/1/2 (backdrop/depth/color), all sharing a chroma-key discard so near-black regions of the painting dissolve into the black void. Perspective-compensated scale per flat: NULL-distance ratio, so head-on all flats subtend the same angle and reassemble at the null.

useStore.jsx: all paintings sit at world (0,0,0); each id gets a stable per-hash viewing direction (Fibonacci-ish on a sphere) and matching rotation so its local +Z aligns with viewDir. Camera path per segment becomes an arc on the sphere of radius NULL_DISTANCE around origin, diving to DIVE_RADIUS=2.5 at r=0.5 (through the shared centre) before climbing out to the next null. Focus is the origin.

AnamorphicCam.jsx: bidirectional scroll — remove the scroll-loopback so scrolling up navigates back through visited segments. Clamp scroll progress to the already-built range; forward scroll extends via buildNextSegment at r>0.5. currentSegmentIndex now syncs both ways.

Scene.jsx: widen the mount window to [current-2, current+2] so backward scroll can still see earlier paintings.


Claude-Session: https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N