### PR TITLE
Fix upright coalescence and black-region bleed

### DIFF
--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -110,11 +110,14 @@ float vnoise(vec2 p) {
 void main() {
   vec3 painting = texture2D(uPainting, vUv).rgb;
 
-  // Chroma-key: kill near-black. BT.709 luma; slight uv-noise threshold
-  // so the edges of dark regions tear organically instead of aliasing.
+  // Chroma-key: kill near-black on cutout flats only (modes 1-2). The
+  // backdrop (mode 0) keeps black pixels opaque so dark painting regions
+  // block whatever is behind — no bleed from other paintings.
   float lum = 0.2126 * painting.r + 0.7152 * painting.g + 0.0722 * painting.b;
-  float chromaJit = (vnoise(vUv * 128.0) - 0.5) * 0.015;
-  if (lum + chromaJit < ${CHROMA_L.toFixed(4)}) discard;
+  if (uMode > 0.5) {
+    float chromaJit = (vnoise(vUv * 128.0) - 0.5) * 0.015;
+    if (lum + chromaJit < ${CHROMA_L.toFixed(4)}) discard;
+  }
 
   if (uMode > 0.5 && uMode < 1.5) {
     // Depth band cutout

--- a/src/store/useStore.jsx
+++ b/src/store/useStore.jsx
@@ -239,7 +239,12 @@ const useStore = create((set, get) => ({
     const theta = edgeRotY(current.id, tid);
     const qEdge = new THREE.Quaternion().setFromAxisAngle(
       new THREE.Vector3(0, 1, 0), theta);
-    const qB = qA.clone().multiply(qEdge);
+    // Multiply then strip any accumulated X/Z tilt — paintings must be
+    // upright at coalescence. Extract only the Y rotation.
+    const qBraw = qA.clone().multiply(qEdge);
+    const yAngle = new THREE.Euler().setFromQuaternion(qBraw, 'YXZ').y;
+    const qB = new THREE.Quaternion().setFromAxisAngle(
+      new THREE.Vector3(0, 1, 0), yAngle);
 
     // Painting A stays where it is (placed by the previous segment's
     // target step, or by setStartNode). Painting B: place at hinge.


### PR DESCRIPTION
## Summary

- **Upright at coalescence:** The rotation chain (`qB = qA * RotY(θ)`) could accumulate floating-point drift in X/Z components over many segments, causing paintings to appear tilted. Now extracts only the Y-rotation after each multiplication and rebuilds a clean quaternion — paintings are always upright when the camera reads them head-on.

- **Black regions stay opaque:** The chroma-key discard (near-black pixels → transparent) was running on the backdrop plane too, which let other paintings' flats bleed through dark regions of the current painting. Now the backdrop skips the chroma-key — its black pixels render as solid opaque black. Cutout flats (depth/color bands) still discard their dark pixels for the torn-shard effect, but the solid backdrop behind them fills those holes.

## Files changed

- `src/store/useStore.jsx` — After `qA.multiply(qEdge)`, extract Y angle via `Euler('YXZ')` and reconstruct a pure Y-axis quaternion
- `src/components/TheaterPainting.jsx` — Gate the chroma-key `discard` behind `uMode > 0.5` so only cutout flats (modes 1–2) dissolve dark pixels; backdrop (mode 0) keeps them opaque

## Test plan

- [ ] Scroll through several segments — paintings should appear level/upright at each coalescence point, no progressive tilting
- [ ] Dark/black regions of a painting should read as solid black, not as windows into the next painting's colors
- [ ] Cutout flats still show torn-paper edges and dissolve dark pixels (the shard effect is preserved)
- [ ] Mid-transition chaos still works — both paintings' flats interleave around the hinge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_

## Summary by Sourcery

Ensure theater paintings remain upright during segment transitions and prevent black regions from bleeding through to underlying paintings.

Bug Fixes:
- Correct painting orientation at coalescence by eliminating accumulated tilt from non‑Y rotation components.
- Restrict near‑black chroma‑key transparency to cutout flats so backdrop blacks stay opaque and no longer reveal other paintings behind.