### PR TITLE
requirements: pin transformers>=4.45.0 for Depth-Anything-V2 pipeline

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,7 +3,7 @@ opencv-python-headless
 Pillow
 pillow-heif
 scipy
-transformers
+transformers>=4.45.0
 timm
 huggingface_hub
 gradio_client


### PR DESCRIPTION
The depth-estimation pipeline for Depth-Anything-V2-Small-hf needs transformers >= 4.45; make the minimum explicit so a future resolve can't land on a version without it.