### PR TITLE
Bake: HEIF opener so .HEIC sources decode (fill 2 skipped paintings)

### DIFF
--- a/.github/workflows/process_art.yml
+++ b/.github/workflows/process_art.yml
@@ -7,9 +7,11 @@ on:
       - 'public/assets/**'
       - 'scripts/grinder.py'
       - 'scripts/indexer.py'
-      - 'scripts/theater_baker.py'
-      - 'scripts/pareidolia_index.py'
       - 'scripts/requirements.txt'
+    # NOTE: theater_baker.py / pareidolia_index.py are deliberately NOT
+    # triggers here. The paper-theater bake + hinge graph + art-data
+    # deploy live in theater_bake.yml, which is the sole publisher of
+    # theater data. This legacy workflow only runs the stroke grinder.
 
 # Cancel previous runs if you push again (prevents queue jams)
 concurrency:
@@ -91,27 +93,12 @@ jobs:
       - name: Index
         run: python scripts/indexer.py
 
-      - name: Bake Theater Layers
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          # Scoped to the 3 curated paintings while the paper-theater
-          # experience is tuned ("until we get this right with 2-3
-          # paintings, it's not worth baking more"). The v2 bake calls
-          # paid/quota'd image models per painting (photorealize +
-          # depth), so do NOT widen this to the full corpus without an
-          # explicit decision.
-          python scripts/theater_baker.py \
-            --input  public/assets/ \
-            --output public/data/theater/ \
-            --ids 'PXL_20230527_000631951~2,2023-10-15(38),20231129_043102~2'
-
-      - name: Build hinge graph
-        run: |
-          # Transition-fulcrum matcher — reads the baked painting+depth
-          # pairs and writes graph.theater.json (the shared patches the
-          # transitions pivot on). Cheap, local, no network.
-          python scripts/pareidolia_index.py --data public/data/theater/
+      # The paper-theater bake (painting/depth/hinge graph) and its
+      # art-data deploy were REMOVED from this workflow. They now live
+      # solely in theater_bake.yml, which bakes the full curated id list
+      # and seeds from art-data. Baking only the original 3 ids here and
+      # deploying would overwrite theater/_manifest.json and collapse the
+      # live gallery back to 3 paintings — so it must never run here.
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
@@ -120,4 +107,8 @@ jobs:
           publish_dir: ./public/data
           publish_branch: art-data
           keep_files: true
-          commit_message: "Turbo Grind + Theater Bake: ${{ github.sha }}"
+          # keep_files:true preserves everything this run didn't produce
+          # — including the entire theater/ tree (paintings, depth maps,
+          # graph, _manifest.json) deployed by theater_bake.yml. This job
+          # writes only stroke/index output, so the gallery is untouched.
+          commit_message: "Turbo Grind (strokes): ${{ github.sha }}"

--- a/.github/workflows/theater_bake.yml
+++ b/.github/workflows/theater_bake.yml
@@ -14,7 +14,7 @@ name: Theater Bake
 # an explicit id list — never the whole 1184-image corpus in one go.
 #
 # Source photos may be .HEIC (iPhone); the baker registers a HEIF
-# opener so those decode. Re-run fills any painting the prior run skipped.
+# opener so those decode. Re-run fills any painting the prior run skipped (HEIC now discovered).
 #
 # Required secret: HF_TOKEN (Hugging Face inference token) for the
 # optional photorealize step. Depth now runs locally (Depth-Anything via

--- a/.github/workflows/theater_bake.yml
+++ b/.github/workflows/theater_bake.yml
@@ -13,6 +13,9 @@ name: Theater Bake
 # painting for the photorealize step, so it is dispatch-only and scoped by
 # an explicit id list — never the whole 1184-image corpus in one go.
 #
+# Source photos may be .HEIC (iPhone); the baker registers a HEIF
+# opener so those decode. Re-run fills any painting the prior run skipped.
+#
 # Required secret: HF_TOKEN (Hugging Face inference token) for the
 # optional photorealize step. Depth now runs locally (Depth-Anything via
 # torch), so a batch no longer degrades to flat/synthetic maps when the

--- a/scripts/theater_baker.py
+++ b/scripts/theater_baker.py
@@ -103,7 +103,7 @@ PHOTOREAL_PROMPT = (
     "identical; only make surfaces, lighting, and materials photorealistic."
 )
 
-IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tif", ".tiff"}
+IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".tif", ".tiff", ".heic", ".heif"}
 
 
 # ---- env --------------------------------------------------------------------

--- a/scripts/theater_baker.py
+++ b/scripts/theater_baker.py
@@ -69,6 +69,16 @@ from PIL import Image, ImageFile
 # avoids derailing a bake over one bad byte.
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
+# Register the HEIF/HEIC opener so PIL can read iPhone .HEIC source photos.
+# Without this, Image.open() throws UnidentifiedImageError on .HEIC and the
+# painting is silently skipped (it never reaches the bake).
+try:
+    import pillow_heif
+    pillow_heif.register_heif_opener()
+except Exception as _heif_exc:  # pragma: no cover - environment dependent
+    print(f"[~] pillow_heif unavailable ({_heif_exc!r}); .HEIC sources will be skipped",
+          file=sys.stderr)
+
 
 # ---- tuning knobs -----------------------------------------------------------
 


### PR DESCRIPTION
## Problem

The 40-painting batch came out with **38** in the manifest. The two missing (`IMG_0232`, `IMG_0607`) are `.HEIC` (iPhone) source photos. `theater_baker.py` called `Image.open()` without registering the `pillow_heif` opener, so PIL raised `UnidentifiedImageError` and those two were silently skipped before the bake.

## Fix

Register `pillow_heif.register_heif_opener()` at import (pillow-heif is already a dependency), with a graceful warning if it's unavailable. Re-runs the bake by touching the workflow; the 38 already-baked paintings seed from `art-data` and skip the expensive stages, so only the two HEIC pieces bake fresh → manifest reaches 40.

## Verification

Run in flight. On success: `art-data` `_manifest.json` lists 40, `IMG_0232` and `IMG_0607` gain real depth (`depth-anything-v2`, not `synthetic`), and the hinge graph spans 40 nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_