### PR TITLE
Fix camera crash on large scroll jumps; re-enable pinch-zoom

### DIFF
--- a/src/components/AnamorphicCam.jsx
+++ b/src/components/AnamorphicCam.jsx
@@ -59,6 +59,13 @@ export default function AnamorphicCam() {
   const segments = useStore(state => state.segments);
   const updateFrame = useStore(state => state.updateFrame);
 
+  // Cache of {index, curve} — CatmullRomCurve3 (and the arc-length LUT it
+  // builds internally on first sample) is only rebuilt when the segment
+  // actually changes, not every frame. This also means a segment's curve
+  // is built exactly once from a stable, fully-formed points array,
+  // rather than freshly re-parametrized every tick.
+  const curveCache = useRef({ index: -1, curve: null });
+
   // Once segments exist, jump the scroll to the painting we open ON —
   // which sits a few segments IN, above the backward buffer — so the
   // viewer can immediately scroll UP into earlier paintings instead of
@@ -100,10 +107,42 @@ export default function AnamorphicCam() {
     // same eased clock (via transitionProgress) so the art resolves
     // exactly as the motion settles — camera in, art revealed.
     const r = rLin * rLin * rLin * (rLin * (rLin * 6 - 15) + 10);
+    // getPointAt requires u in [0,1]; the upstream clamp keeps rLin just
+    // under 1 in the normal case, but a large/instant scroll jump (a
+    // scrollbar-thumb drag, Home/End) can hand this a value that's
+    // *effectively* 1 after float rounding, which THREE's arc-length
+    // lookup doesn't tolerate gracefully — clamp explicitly rather than
+    // trust every upstream path to land inside range.
+    const rSafe = Math.min(1, Math.max(0, r));
 
-    const curve = new THREE.CatmullRomCurve3(currentSegment.path);
-    camera.position.copy(curve.getPointAt(r));
-    camera.lookAt(lookTarget(segments, segmentIndex, r));
+    if (curveCache.current.index !== segmentIndex) {
+      curveCache.current = {
+        index: segmentIndex,
+        curve: new THREE.CatmullRomCurve3(currentSegment.path),
+      };
+    }
+    try {
+      const p = curveCache.current.curve.getPointAt(rSafe);
+      // A degenerate segment (e.g. near-coincident start/hinge/end points
+      // from an edge case in the placement math) can hand back a
+      // non-finite point even without throwing. Never feed that to the
+      // camera — hold the last good position instead of snapping to
+      // NaN/Infinity, which would blank the canvas.
+      if (Number.isFinite(p.x) && Number.isFinite(p.y) && Number.isFinite(p.z)) {
+        camera.position.copy(p);
+      }
+      camera.lookAt(lookTarget(segments, segmentIndex, rSafe));
+    } catch (err) {
+      // Never let a curve-sampling edge case turn into a permanent,
+      // every-frame-repeating crash loop (observed: CatmullRomCurve3's
+      // arc-length search throwing on a large/instant scroll jump) — hold
+      // the camera at its last good position for this frame and recover
+      // on the next one instead of freezing the whole experience.
+      if (!curveCache.current.warned) {
+        console.warn('[AnamorphicCam] curve sample failed, holding position:', err);
+        curveCache.current.warned = true;
+      }
+    }
 
     // Single atomic update: transitionProgress and currentSegmentIndex
     // (which drives which paintings <Scene> mounts) always change

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,10 @@ body {
   height: 100%;
 }
 
-canvas {
-  touch-action: none; /* Disable default touch actions for custom gestures */
-}
+/* No touch-action override on canvas: nothing in this app implements a
+   custom touch gesture (grepped — no touchstart/touchmove/pointerdown
+   handlers anywhere), and the canvas fills the entire viewport, so a
+   blanket touch-action:none here was blocking pinch-zoom everywhere on
+   screen — silently defeating the viewport-meta fix that was supposed to
+   re-enable it. Native drei ScrollControls hijacks scroll via its own
+   overflow:auto div, unaffected by this. */

--- a/src/store/useStore.jsx
+++ b/src/store/useStore.jsx
@@ -513,8 +513,6 @@ const useStore = create((set, get) => ({
       activeClusters: [...activeClusters, nextCluster],
       segments: [...segments, newSegment],
     });
-
-    console.log(`[Store] Segment ${segments.length} Appended: ${current.id} -> ${tid} (θ=${(theta*180/Math.PI).toFixed(1)}°)`);
   },
 
   // Atomic per-frame update: AnamorphicCam calls this ONCE per frame with


### PR DESCRIPTION
## Summary

Fixes issues surfaced by the UI-flow glee audit run against the hinge-alignment fix (#61, already merged).

**Fixed:**
- **Camera crash on large/instant scroll jumps** (scrollbar-thumb drag, Home/End, a hard flick): `CatmullRomCurve3.getPointAt()` threw inside `AnamorphicCam`'s `useFrame` and never recovered — the error repeated every frame indefinitely, freezing the camera. Confirmed gradual scrolling never triggers it. `AnamorphicCam.jsx` now memoizes the curve per segment (instead of rebuilding it, with a fresh uncached arc-length table, every single frame), explicitly clamps `r` into `[0,1]` before sampling, validates the sampled point is finite before applying it to the camera, and wraps the sample in try/catch so a curve-math edge case can't turn into a permanent crash loop again.
- **Pinch-zoom still didn't actually work** despite an earlier fix removing the viewport-meta restriction: `index.css` had a blanket `touch-action: none` on `<canvas>` with zero custom touch/pointer handlers anywhere in the codebase to justify it — silently defeating that earlier fix. Removed.
- Removed a per-transition debug `console.log` left in `useStore.jsx`'s `buildNextSegment`.

**Known remaining issue, NOT fixed here** — two light-background ("paper") rendering findings from the same audit:
1. Light-bg *detection* missing a piece that qualifies by its own 0.62 luminance threshold. I reproduced the detection algorithm exactly against the real asset in Chromium and confirmed it computes the correct result (0.79 > 0.62) — so this is very likely a timing race under the same large-jump interaction class this PR hardens against, not an algorithm bug.
2. The background-sweep-to-white not visibly firing for at least one confirmed light piece. I investigated at length (the fade/timeline math and the fullscreen-quad shader both check out structurally) but could not get a conclusive live reproduction in this sandbox's resource-constrained Playwright environment. Reporting honestly as unresolved rather than guessing at a fix without evidence.

## Verification

- `npm run build` — clean, exit 0.
- Reproduced the original crash trigger against the built site (massive wheel deltas, direct `scrollTop` jumps, rapid back-and-forth flicks) — zero page errors after the fix, versus reliably crashing before it.
- Screenshot after a large jump shows the normal drei loading indicator (new textures loading), not a blank/broken frame.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_

## Summary by Sourcery

Harden camera behavior against large/instant scroll jumps and restore native pinch-zoom interactions.

Bug Fixes:
- Prevent the anamorphic camera from crashing or freezing on large or instantaneous scroll jumps by making curve sampling robust to out-of-range or invalid values.
- Restore pinch-zoom support on touch devices by removing the blanket touch-action override from the canvas element.

Enhancements:
- Improve camera path handling by reusing segment curves instead of rebuilding them every frame, reducing per-frame overhead and avoiding curve instability on large jumps.

Chores:
- Remove leftover debug logging from the store segment-building logic.