### PR TITLE
Fix background-sweep uniform stomping and wire baked patchScale

### DIFF
--- a/src/components/Scene.jsx
+++ b/src/components/Scene.jsx
@@ -1,4 +1,5 @@
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense, useEffect, useMemo } from 'react';
+import * as THREE from 'three';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { ScrollControls, PerspectiveCamera } from '@react-three/drei';
 import { useStore } from '../store/useStore';
@@ -37,21 +38,29 @@ void main(){
 }
 `;
 function BackgroundSweep() {
-  const matRef = React.useRef();
-  useFrame(() => {
-    if (matRef.current) matRef.current.uniforms.uLevel.value = bgSweepLevel();
-  });
+  // Built imperatively (not via JSX <shaderMaterial uniforms={...}>) for the
+  // same reason TheaterPainting's flat materials are: a plain uniforms object
+  // literal in JSX has no .set()/.copy(), so react-three-fiber's applyProps
+  // falls through to `currentInstance.uniforms = value` on every re-render —
+  // wholesale REPLACING the uniforms object, including whatever this
+  // component's own useFrame just wrote into it. Scene re-renders on every
+  // updateFrame() (i.e. continuously during scroll), which was silently
+  // stomping uLevel back to its initial 0 almost every frame — the sweep
+  // was computing correctly and never reaching the screen. A stable,
+  // useMemo'd material sidesteps prop-diffing entirely: the mutation below
+  // is the only thing that ever touches uLevel.
+  const material = useMemo(() => new THREE.ShaderMaterial({
+    vertexShader: bgWipeVS,
+    fragmentShader: bgWipeFS,
+    uniforms: { uLevel: { value: 0 } },
+    depthTest: false,
+    depthWrite: false,
+  }), []);
+  useEffect(() => () => material.dispose(), [material]);
+  useFrame(() => { material.uniforms.uLevel.value = bgSweepLevel(); });
   return (
-    <mesh frustumCulled={false} renderOrder={-1000}>
+    <mesh frustumCulled={false} renderOrder={-1000} material={material}>
       <planeGeometry args={[1, 1]} />
-      <shaderMaterial
-        ref={matRef}
-        vertexShader={bgWipeVS}
-        fragmentShader={bgWipeFS}
-        uniforms={{ uLevel: { value: 0 } }}
-        depthTest={false}
-        depthWrite={false}
-      />
     </mesh>
   );
 }

--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -29,6 +29,11 @@ const CHROMA_L          = 0.045;    // luminance below this counts as "black" â†
 // black over this many units instead of clipping the near plane.
 const CROSS_FADE = 1.2;
 
+// Fulcrum-reveal patch radius used when a segment has no baked patchScale
+// (the degenerate/no-graph-edge fallback cases) â€” otherwise it's derived
+// per-transition from pareidolia_index.py's real matched-patch size.
+const DEFAULT_PATCH_R = 0.14;
+
 // Light-background pieces overfill the frame at coalescence so the paper's
 // own edges sit off-screen (only the swept site background, never a rectangle).
 const LIGHT_BG_OVERFILL = 1.35;
@@ -437,7 +442,7 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
       uFade:          { value: 0 },
       uRole:          { value: 0 },
       uPatchUv:       { value: new THREE.Vector2(0.5, 0.5) },
-      uPatchR:        { value: 0.14 },
+      uPatchR:        { value: DEFAULT_PATCH_R },
       uReveal:        { value: 0 },
       uWipe:          { value: 1 },
       uBgLight:       { value: 0 },
@@ -625,8 +630,14 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
     const cur = st.currentSegmentIndex;
     const seg = st.segments[cur];
     const r = st.transitionProgress;
-    let role = 0, patch = null, reveal = 0;
+    let role = 0, patch = null, reveal = 0, patchR = DEFAULT_PATCH_R;
     if (seg) {
+      // pareidolia_index.py bakes the real matched-patch edge length per
+      // edge (seg.patchScale, a fraction of the painting's min dimension);
+      // halve it (edge -> radius) so the reveal circle's size actually
+      // reflects that specific match instead of one fixed guess for every
+      // transition in the gallery.
+      if (typeof seg.patchScale === 'number') patchR = seg.patchScale / 2;
       if (mySegmentIndex === cur) {
         role = 1;               // outgoing
         patch = seg.sUv;
@@ -655,6 +666,7 @@ export default function TheaterPainting({ id, image, position, rotation, mySegme
       U.uRole.value = role;
       U.uReveal.value = reveal;
       if (patch) U.uPatchUv.value.set(patch[0], patch[1]);
+      U.uPatchR.value = patchR;
     }
     fallbackMaterial.color.setScalar(fade);
   });

--- a/src/store/useStore.jsx
+++ b/src/store/useStore.jsx
@@ -507,6 +507,13 @@ const useStore = create((set, get) => ({
       // incoming painting outward from it.
       sUv: aSuv,
       tUv: edge.t_uv || [0.5, 0.5],
+      // pareidolia_index.py bakes the matched patch's real edge length
+      // (as a fraction of the painting's min dimension) per edge — pass it
+      // through so the fulcrum-reveal circle's radius reflects the actual
+      // match size instead of a fixed guess. Null for edges without one
+      // (the degenerate/no-graph-edge fallbacks), so the renderer can fall
+      // back to its own default.
+      patchScale: typeof edge.scale === 'number' ? edge.scale : null,
     };
 
     set({


### PR DESCRIPTION
## Summary

Two fixes from a thorough visual bug-hunt audit of the gallery's rendering:

- **Background-sweep never rendered.** `BackgroundSweep`'s `<shaderMaterial uniforms={{...}}>` used a plain JSX object literal for `uniforms`, which has no `.set()`/`.copy()`. React-three-fiber's `applyProps` falls back to wholesale-replacing `currentInstance.uniforms` on every re-render of `Scene`, which happens continuously during scroll (`updateFrame()`). That silently reset `uLevel` back to `0` almost every frame right after `useFrame` had just written it — the white sweep was computing correctly but never reaching the screen. Fixed by building the material imperatively with a memoized `THREE.ShaderMaterial` (mirroring the pattern `TheaterPainting.jsx` already uses for the same class of bug), so the `useFrame` mutation is the only thing that ever touches `uLevel`.
- **Baked patch scale was computed but never used.** `pareidolia_index.py` bakes each hinge edge's real matched-patch size (`edge.scale`, a fraction of the painting's min dimension) at bake time, but the renderer's fulcrum-reveal circle radius (`uPatchR`) was hardcoded to a single constant (`0.14`) for every transition in the gallery. Wired `edge.scale` through `buildNextSegment` → `segment.patchScale` → `TheaterPainting`'s `uPatchR`, falling back to the old constant (now named `DEFAULT_PATCH_R`) for edges without a baked scale.

## Verification

- Both fixes build cleanly (`npm run build`).
- The background-sweep fix was verified empirically, not just by inspection: a temporary debug hook confirmed `uLevel` correctly rises to ~1.0 during a light-background painting's coalescence (previously it was being stomped back to 0 almost immediately), and a real `page.screenshot()` taken at `uLevel≈0.86` shows the frame buffer genuinely light/white rather than black. The debug hook was removed before this commit.

## Test plan

- [x] `npm run build` succeeds
- [x] Screenshot-verified the background sweep actually renders white at high `uLevel` (not just computed in JS)
- [ ] CI (lint/build/deploy checks)


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_

## Summary by Sourcery

Fix background sweep rendering and apply baked patch scale to fulcrum reveal transitions in the gallery.

New Features:
- Use per-edge baked patch scale to drive fulcrum-reveal circle radius, with a default fallback when no scale is available.

Bug Fixes:
- Ensure background sweep shader material retains its uniforms during scroll so uLevel updates are visible on screen.
- Wire baked edge.scale values through store segments to TheaterPainting so reveal patch size reflects the actual matched patch instead of a constant.

Enhancements:
- Introduce a named DEFAULT_PATCH_R constant to centralize the renderer’s fallback patch radius configuration.