### PR TITLE
Restore fine-grain torn-paper tear noise at depth-band edges

### DIFF
--- a/docs/SHADERS.md
+++ b/docs/SHADERS.md
@@ -49,10 +49,12 @@ void main() {
 
 Per flat, in order:
 
-1. **Depth-band cutout.** Sample `uDepth` at `vUv`, jitter it by a coarse
-   value-noise term (`vnoise(vUv * 48.0)`) so the band boundary reads as a
-   torn-paper edge instead of a razor line, and discard if the jittered
-   depth falls outside `[uBandMin, uBandMax)`.
+1. **Depth-band cutout.** Sample `uDepth` at `vUv`, jitter it by two
+   stacked value-noise terms — a coarse `vnoise(vUv * 48.0)` for the big
+   organic tears and a finer `vnoise(vUv * 320.0)` for paper-fiber grain —
+   so the band boundary reads as a torn-paper edge instead of a razor
+   line, and discard if the jittered depth falls outside
+   `[uBandMin, uBandMax)`.
 2. **Background matte.** Dark-background paintings chroma-key: luminance
    below `CHROMA_L` (0.045, plus a little noise jitter) discards, so black
    regions dissolve into the black void. Light-background ("paper")
@@ -90,14 +92,23 @@ gl_FragColor = vec4(painting * op, 1.0);
 This was tried and reverted; the reasoning is preserved as an in-shader
 comment so it survives future edits, but the short version:
 
-- The original bug (visible sparkle/flicker as paintings coalesced) was
-  overwhelmingly caused by a very-high-frequency `hash(vUv * 1024.0)` term
-  in the tear noise aliasing badly as the camera's sub-pixel position
-  shifted between frames. Removing that term (the coarser
-  `vnoise(vUv * 48.0)` alone is enough to keep the edge organic) fixed the
-  actual problem.
-- The first attempted fix instead added an `fwidth()`-based `bandAlpha`
-  ramp that faded opacity near the boundary, to antialias it. This
+- The original flicker bug (visible sparkle as paintings coalesced) was
+  driven by a raw `hash(vUv * 1024.0)` fine-grain term in the tear noise:
+  `hash()` is a discontinuous per-cell lookup, not band-limited, so a
+  sub-texel shift in `vUv` (from the camera's sub-pixel position moving
+  frame to frame) could flip its output entirely, aliasing badly.
+- A first pass fixed the flicker by deleting that term outright, leaving
+  only the coarse `vnoise(vUv * 48.0)` wave. That killed the flicker, but
+  the fine grain was also what made the torn edge read as fibrous ripped
+  paper — losing it left only smooth, blobby regions, which (compounded by
+  the `bandAlpha` regression below) read as a topographic contour map
+  instead of torn paper. The fix that stuck: a *second* fine-grain term
+  built from `vnoise(vUv * 320.0)` instead of raw `hash`. `vnoise()`
+  interpolates smoothly between its grid corners, so a sub-texel `vUv`
+  shift only nudges its output a little instead of jumping randomly —
+  getting the paper-fiber texture back without reintroducing the alias.
+- Separately, one attempted fix along the way added an `fwidth()`-based
+  `bandAlpha` ramp that faded opacity near the boundary, to antialias it. This
   *reduced* the flicker but introduced a new, worse, static defect: every
   one of the ~18 band boundaries per painting drew as a permanent
   darkened contour line, so a fully-coalesced painting looked like a

--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -197,16 +197,25 @@ void main() {
   //
   // A plain hard discard has no such line: two adjacent bands show the
   // exact SAME painting pixel at full, undimmed brightness right up to
-  // their shared boundary, so there's nothing to see a seam in. What
-  // actually drove most of the original flicker was a since-removed
-  // very-high-frequency hash(vUv*1024.0) term in the tear noise, which
-  // aliased badly as the camera's sub-pixel position shifted frame to
-  // frame; the coarser vnoise(vUv*48.0) term alone already keeps that
-  // under control without needing to fake antialiasing here.
+  // their shared boundary, so there's nothing to see a seam in.
+  //
+  // The original flicker was driven by a raw hash(vUv*1024.0) fine-grain
+  // term in the tear noise: hash() is a discontinuous per-cell lookup, not
+  // band-limited, so a sub-texel shift in vUv (from the camera's sub-pixel
+  // position moving frame to frame) could flip its output entirely,
+  // aliasing badly. A first pass fixed the flicker by deleting that term
+  // outright — but the fine grain was also what made the torn edge read as
+  // fibrous ripped paper; losing it left only the coarse vnoise(48) wave,
+  // which reads as smooth blobby regions (a "topographic map") instead.
+  // vnoise() interpolates smoothly between its grid corners (unlike raw
+  // hash), so a SECOND fine-grain term built from vnoise at high frequency
+  // gets the paper-fiber texture back without the aliasing: a sub-texel vUv
+  // shift now only nudges the output a little, not a full random jump.
   bool bandDiscard = false;
   if (uMode > 0.5 && uMode < 1.5) {
     float d = texture2D(uDepth, vUv).r;
-    float tear = (vnoise(vUv * 48.0) - 0.5) * 0.05;
+    float tear = (vnoise(vUv * 48.0) - 0.5) * 0.05
+               + (vnoise(vUv * 320.0) - 0.5) * 0.012;
     float dj = d + tear;
     bandDiscard = dj < uBandMin || dj >= uBandMax;
   }


### PR DESCRIPTION
## Summary

This session's very first change (aimed at fixing a coalescence-flicker bug) deleted the fine `hash(vUv * 1024.0)` tear-noise term from `TheaterPainting.jsx`'s depth-band cutout shader instead of fixing why it aliased. That did kill the flicker, but it also removed the fibrous "ripped paper" grain the user specifically liked — leaving only the coarse `vnoise(vUv * 48.0)` wave, which reads as smooth blobby regions ("a topographic map") instead of torn paper, most visibly on high-detail/high-contrast paintings.

Root cause of the original flicker: `hash()` is a discontinuous per-cell lookup, not band-limited, so any sub-texel shift in `vUv` (from the camera's sub-pixel position moving frame to frame) could flip its output entirely.

## Fix

Restore the fine-grain term, but build it from `vnoise()` instead of raw `hash()`. `vnoise()` interpolates smoothly between its grid corners, so a sub-texel `vUv` shift only nudges the output a little rather than jumping randomly — this should get the paper-fiber texture back without reintroducing the original aliasing.

```glsl
float tear = (vnoise(vUv * 48.0) - 0.5) * 0.05
           + (vnoise(vUv * 320.0) - 0.5) * 0.012;
```

Also updates `docs/SHADERS.md`'s tear-noise description and "why hard discard" section to match.

## Verification

- Loaded the live dev build, used the Zustand store directly to bisect scroll position to real, mathematically exact coalescence points (`transitionProgress` ≈ 0), and screenshotted several paintings there — confirmed the pre-fix state showed scattered perforation holes at true coalescence on high-detail paintings (not just a transition-in-progress artifact), and the new formula produces fine scratchy grain instead.
- `npm run build` passes.
- A same-scroll-offset flicker sanity check (nudging the null position by a few px and comparing) was attempted but the headless screenshot tooling in this environment was too slow/flaky to complete it reliably. The fix rests on the code-level reasoning above (continuous `vnoise` vs. discontinuous `hash`) rather than an empirical flicker A/B; flagging this so it can be watched for on the deployed site.

## Test plan

- [ ] Confirm depth-band edges read as fine torn paper (not smooth blobby regions) at real coalescence on a few different paintings, especially high-detail ones.
- [ ] Confirm no flicker/sparkle has returned at coalescence during normal scrolling.


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_

## Summary by Sourcery

Replace the aliased fine tear noise with smoothly interpolated high-frequency noise to bring back fibrous paper grain while preserving stable depth-band rendering.

Bug Fixes:
- Restore fine-grained torn-paper texture at depth-band edges without reintroducing the coalescence flicker caused by discontinuous noise.

Enhancements:
- Document the updated tear-noise behavior and rationale for retaining hard discard boundaries.

Documentation:
- Update shader documentation to describe the coarse and fine value-noise layers and the aliasing trade-offs.