### PR TITLE
Fix coalescence misalignment: zero the camera's off-axis null offset

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -118,6 +118,20 @@ coalesces, and back as it leaves — driven by `bgSweepLevel()`, the max
 across all currently-mounted light-background paintings' individual
 pulls on it.
 
+A related pitfall, but in the camera math rather than the shader:
+`useStore.jsx`'s `computeSegmentPlacement()` used to offset the camera's
+"null" viewpoint laterally off the painting's true normal (`OFF_AXIS`,
+originally 0.045 × `NULL_DISTANCE`), on purpose, so the flats would never
+click fully flat. Because the depth-band flats are hard-discard cutouts
+with zero overlap between bands, that offset introduced real parallax
+between flats at different depths even at the mathematically exact
+coalescence point — confirmed live via screenshots at a bisected
+`transitionProgress ≈ 0`, which showed scattered perforation holes on
+high-detail paintings. `OFF_AXIS` is now `0`: the null is truly
+axis-aligned, and the mid-transition parallax/shard-explosion still comes
+entirely from the camera's dive path swinging through the shared hinge
+(`divePath()`), so nothing about the drama of a transition was lost.
+
 ### 5. State: Zustand, one atomic per-frame update
 
 `src/store/useStore.jsx` holds the loaded graph, the walked sequence of

--- a/src/store/useStore.jsx
+++ b/src/store/useStore.jsx
@@ -2,18 +2,22 @@ import { create } from 'zustand';
 import * as THREE from 'three';
 import { NULL_DISTANCE, PAINTING_HEIGHT, CAMERA_FOV_DEG } from '../sceneConstants';
 
-// How far off the painting's normal the null viewpoint sits, as a
-// fraction of NULL_DISTANCE. Nonzero so the flats NEVER fully close up:
-// even at coalescence there's a whisper of parallax — the painting is
-// never shown as the flat original.
-// Off-axis fraction of the null viewpoint. This is what keeps the
-// painting from EVER re-closing perfectly flat — but it also sets how
-// far the depth bands slide apart at the null, so it must stay a
-// whisper: enough that the flats never quite click shut, not so much
-// that the flat background regions visibly separate into panels. The
-// big shard explosion during a transition comes from the camera's full
-// swing off the axis, not from this, so shrinking it doesn't cost drama.
-const OFF_AXIS = 0.045;
+// Off-axis fraction of the null viewpoint, as a fraction of NULL_DISTANCE.
+// Was 0.045 (a deliberate "whisper of parallax" so the painting never
+// closes up perfectly flat) — but the depth-band flats are hard-discard
+// cutouts with zero overlap between bands (see TheaterPainting.jsx), so
+// ANY camera offset at the null introduces real parallax between flats at
+// different depths, and with no blend to absorb it, that parallax punches
+// straight through as visible gaps between bands. Invisible on smooth
+// content, glaring on high-detail content — confirmed live: paintings
+// photographed at the mathematically exact coalescence point (
+// transitionProgress bisected to ~0) still showed scattered perforation
+// holes, because the camera was never actually looking straight down the
+// painting's normal even there. Zeroed so the null is truly axis-aligned;
+// the dramatic mid-transition parallax/shard-explosion comes entirely
+// from the camera's dive path swinging through the shared hinge (see
+// divePath below), not from this, so this costs no drama.
+const OFF_AXIS = 0.0;
 
 // Reproduces TheaterPainting.jsx's fitScale useMemo EXACTLY (same
 // NULL_DISTANCE, same FOV, same 0.85/0.90 fit margins, same


### PR DESCRIPTION
## Summary

- The depth-band flats in `TheaterPainting.jsx` are opaque, hard-discard cutouts with zero overlap between bands — by design, to avoid the earlier topographic-contour regression.
- `computeSegmentPlacement()` in `useStore.jsx` deliberately offset the camera's "null" viewpoint laterally off each painting's true normal (`OFF_AXIS`, 4.5% of `NULL_DISTANCE`) so the depth layers would never click fully flat.
- That offset introduces real parallax between flats sitting at different depths, even at the mathematically exact coalescence point — confirmed live via screenshots at a bisected `transitionProgress ≈ 0`, which showed scattered perforation holes on high-detail paintings (invisible on smooth content, where the shift is sub-pixel).
- `OFF_AXIS` is now `0`. The null is truly axis-aligned; the mid-transition parallax/shard-explosion is unaffected, since that comes entirely from the camera's dive path swinging through the shared hinge (`divePath()`), a separate mechanism.
- `docs/ARCHITECTURE.md` updated with a note on this pitfall alongside the existing shader-flicker/contour-line history.

## Test plan

- [x] `npm run build` succeeds
- [x] Verified locally via a headless probe that bisects real scroll positions to `transitionProgress ≈ 0` and screenshots: before the fix, high-detail paintings showed scattered perforation holes even at the exact coalescence point; after zeroing `OFF_AXIS`, the same methodology shows a clean, fully-aligned reassembly


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_

## Summary by Sourcery

Align the camera with each painting's normal at coalescence so depth-band layers reassemble cleanly without affecting transition motion.

Bug Fixes:
- Fix painting coalescence artifacts by making the camera's null viewpoint axis-aligned, eliminating visible gaps and perforation holes between depth bands at the exact reassembly point.

Enhancements:
- Document the camera-offset pitfall and clarify that transition drama remains driven by the dive path.

Documentation:
- Document the cause and resolution of depth-band misalignment at coalescence in the architecture guide.