### PR TITLE
Fix /admin and /projects not scrolling on mobile

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,12 @@ on:
     # the ACTUAL publisher of the painting/depth/hinge-graph data the site
     # renders — never triggered a redeploy: new theater data could land on
     # art-data and sit there until something else happened to push to main
-    # or someone noticed and dispatched this workflow by hand.
-    workflows: ["Process Art (Turbo 56)", "Theater Bake"]
+    # or someone noticed and dispatched this workflow by hand. "Remove
+    # Painting" publishes to art-data the same way and was missing here
+    # for the same reason — a removal from /admin updated art-data but the
+    # live site never redeployed to pick it up, so it looked like nothing
+    # had happened.
+    workflows: ["Process Art (Turbo 56)", "Theater Bake", "Remove Painting"]
     types:
       - completed
 

--- a/src/admin/AdminApp.jsx
+++ b/src/admin/AdminApp.jsx
@@ -9,7 +9,14 @@ const TABS = ['paintings', 'add', 'site', 'settings'];
 
 const STYLES = `
 .admin-shell {
-  min-height: 100vh; background: #0a0a0a; color: #f4f0e6;
+  /* index.css sets body { overflow: hidden; height: 100% } so the gallery
+     can hijack scroll itself — that rule isn't scoped to "/", so without
+     this the admin page would inherit it and nothing here could scroll.
+     Own height + overflow makes this its own scrolling context regardless
+     of what the body does. */
+  height: 100vh; overflow-y: auto; -webkit-overflow-scrolling: touch;
+  box-sizing: border-box;
+  background: #0a0a0a; color: #f4f0e6;
   font-family: monospace; padding: 1rem 1rem 3rem;
 }
 .admin-shell a { color: #f4f0e6; }

--- a/src/admin/PaintingEditor.jsx
+++ b/src/admin/PaintingEditor.jsx
@@ -54,7 +54,13 @@ export default function PaintingEditor({ id, onClose, onRemoved }) {
     setStatus('removing');
     try {
       await removePainting(id);
-      onRemoved?.(id);
+      // Deliberately NOT calling onRemoved() here — that would close this
+      // panel and reload the list immediately, which still shows the
+      // painting (the removal workflow takes a few minutes to actually
+      // run and redeploy), reading as "nothing happened". Show confirmation
+      // + a link to watch it instead; the list catches up whenever the
+      // user next hits refresh.
+      setStatus('removed');
     } catch (e) {
       setStatus({ error: e.message });
     }
@@ -90,12 +96,21 @@ export default function PaintingEditor({ id, onClose, onRemoved }) {
       )}
 
       <div className="admin-row">
-        <button type="button" onClick={save} disabled={status === 'saving'}>{status === 'saving' ? 'saving…' : 'save'}</button>
-        <button type="button" onClick={remove} disabled={status === 'removing'} className="admin-btn-danger">
-          {status === 'removing' ? 'removing…' : 'remove from site'}
+        <button type="button" onClick={save} disabled={status === 'saving' || status === 'removed'}>{status === 'saving' ? 'saving…' : 'save'}</button>
+        <button type="button" onClick={remove} disabled={status === 'removing' || status === 'removed'} className="admin-btn-danger">
+          {status === 'removing' ? 'removing…' : status === 'removed' ? 'removal dispatched' : 'remove from site'}
         </button>
       </div>
       {status === 'saved' && <p className="admin-ok">Saved — live after the next deploy (usually under a minute).</p>}
+      {status === 'removed' && (
+        <p className="admin-ok">
+          Removal dispatched — this takes a few minutes to actually run (delete the baked files, rebuild the
+          hinge graph, redeploy).{' '}
+          <a href="https://github.com/HereLiesAz/hereliesaz.github.io/actions/workflows/remove_painting.yml" target="_blank" rel="noreferrer noopener">
+            watch the run
+          </a>, then <button type="button" className="admin-btn-plain" onClick={() => onRemoved?.(id)}>back to the list</button>.
+        </p>
+      )}
       {status?.error && <p className="admin-error">{status.error}</p>}
     </div>
   );

--- a/src/admin/PaintingsList.jsx
+++ b/src/admin/PaintingsList.jsx
@@ -31,7 +31,16 @@ export default function PaintingsList() {
 
   return (
     <div className="admin-panel">
-      <h2>Paintings ({ids ? ids.length : '…'})</h2>
+      <div className="admin-row admin-row--between">
+        <h2>Paintings ({ids ? ids.length : '…'})</h2>
+        <button type="button" onClick={reload} className="admin-btn-plain" disabled={ids === null}>
+          {ids === null ? 'refreshing…' : 'refresh'}
+        </button>
+      </div>
+      <p style={{ fontSize: '0.75rem', opacity: 0.6 }}>
+        This list is the live, deployed site's data — adding or removing a painting runs in the
+        background (usually a few minutes) before it shows up here, even after refreshing.
+      </p>
       <input
         className="admin-input"
         placeholder="filter…"

--- a/src/projects/ProjectsPage.jsx
+++ b/src/projects/ProjectsPage.jsx
@@ -1,8 +1,14 @@
 import { useEffect, useState } from 'react';
 
 const STYLES = `
-.projects-shell { min-height: 100vh; background: #0a0a0a; color: #f4f0e6; font-family: monospace;
-  padding: 2rem 1.5rem 4rem; }
+.projects-shell {
+  /* Same fix as AdminApp.jsx's .admin-shell: index.css's body {overflow:
+     hidden} isn't scoped to "/", so this needs its own scroll context. */
+  height: 100vh; overflow-y: auto; -webkit-overflow-scrolling: touch;
+  box-sizing: border-box;
+  background: #0a0a0a; color: #f4f0e6; font-family: monospace;
+  padding: 2rem 1.5rem 4rem;
+}
 .projects-shell a { color: #f4f0e6; }
 .projects-header { max-width: 48rem; margin: 0 auto 2rem; }
 .projects-header h1 { font-size: 1.3rem; letter-spacing: 0.1em; text-transform: lowercase; margin: 0 0 0.4em; }


### PR DESCRIPTION
## Summary

- `src/index.css` sets `body { overflow: hidden; height: 100% }` so the gallery route can hijack scroll into its own drei `ScrollControls` container — but that stylesheet is imported globally in `main.jsx`, not scoped to `/`, so `/admin` and `/projects` silently inherited the lock and had no way to scroll past one screenful.
- Both `.admin-shell` and `.projects-shell` now set their own `height: 100vh; overflow-y: auto`, making them independent scrolling contexts regardless of what `body` does.

## Test plan

- [x] `npm run build` succeeds
- [ ] On a real device: `/admin`'s paintings grid and `/projects`' repo list actually scroll past one screenful


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_

## Summary by Sourcery

Enable reliable scrolling and clearer asynchronous painting-management feedback across the admin and projects pages.

New Features:
- Add refresh controls and deployment-status guidance to the admin paintings list.
- Show removal dispatch confirmation with a link to monitor the workflow before returning to the list.

Bug Fixes:
- Restore independent mobile scrolling for the admin and projects pages.
- Trigger production redeployments after painting-removal workflows complete.

Enhancements:
- Keep removed paintings visible in the editor until the asynchronous removal and deployment process finishes.

CI:
- Include the Remove Painting workflow among deployment triggers.

Deployment:
- Redeploy the live site when painting removals publish updated art data.