### PR TITLE
Fix bugs found by a full glee audit (shader, routing, CI/CD, bake pipeline, admin app)

### DIFF
--- a/.github/workflows/deploy-sftp.yml
+++ b/.github/workflows/deploy-sftp.yml
@@ -54,8 +54,11 @@ on:
     # branch never mirrored to the SFTP host on its own — main and the SFTP
     # mirror could silently diverge from GitHub Pages (deploy.yml, which
     # does watch these) until someone happened to push to main. Names must
-    # exactly match the target workflows' `name:` fields.
-    workflows: ["Process Art (Turbo 56)", "Theater Bake"]
+    # exactly match the target workflows' `name:` fields. "Remove Painting"
+    # and "Bootstrap Art (5 Images)" both publish to art-data the same way
+    # and were originally missing here too — this list must stay in sync
+    # with deploy.yml's own workflow_run list.
+    workflows: ["Process Art (Turbo 56)", "Theater Bake", "Remove Painting", "Bootstrap Art (5 Images)"]
     types:
       - completed
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,11 @@ on:
     # Painting" publishes to art-data the same way and was missing here
     # for the same reason — a removal from /admin updated art-data but the
     # live site never redeployed to pick it up, so it looked like nothing
-    # had happened.
-    workflows: ["Process Art (Turbo 56)", "Theater Bake", "Remove Painting"]
+    # had happened. "Bootstrap Art (5 Images)" publishes to art-data too
+    # and is included for the same reason, even though it's a one-time
+    # seeding workflow unlikely to run again — nothing marks it retired,
+    # so leaving it off this list would be a live trap if it ever is.
+    workflows: ["Process Art (Turbo 56)", "Theater Bake", "Remove Painting", "Bootstrap Art (5 Images)"]
     types:
       - completed
 

--- a/.github/workflows/process_art.yml
+++ b/.github/workflows/process_art.yml
@@ -31,6 +31,16 @@ concurrency:
 jobs:
   grind:
     runs-on: ubuntu-latest
+    # /admin's removePainting() (src/admin/data.js) deletes the source
+    # photo from public/assets/ as part of removing a painting — a real
+    # push touching this job's own path filter, since GitHub Actions path
+    # filters match files removed in the diff, not just added/modified.
+    # That would kick off this entire 56-shard grinder for a file being
+    # deleted, wastefully, and contend with the actual removal's publish
+    # via the shared art-data-publish concurrency group. removePainting()
+    # tags its commit message with [skip-grind] specifically so this job
+    # (and consolidate below, via needs:) can opt out.
+    if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip-grind]')
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/remove_painting.yml
+++ b/.github/workflows/remove_painting.yml
@@ -61,9 +61,20 @@ jobs:
           rsync -a --exclude='.git' _artdata/ public/data/
 
       - name: Delete baked artifacts for this id
+        env:
+          # Passed via env, not spliced directly into the script as
+          # `${{ github.event.inputs.id }}` — see theater_bake.yml's "Bake
+          # theater layers" step for why direct interpolation into a run:
+          # script is a shell-injection primitive. This job has
+          # contents:write, so an unescaped id is a real risk, not just
+          # theoretical.
+          ID_INPUT: ${{ github.event.inputs.id }}
         run: |
-          ID="${{ github.event.inputs.id }}"
+          ID="$ID_INPUT"
           if [ -z "$ID" ]; then echo "::error::id input is required"; exit 1; fi
+          case "$ID" in
+            */*|*..*) echo "::error::id must not contain path separators or '..'"; exit 1 ;;
+          esac
           DIR="public/data/theater"
           FOUND=0
           for suffix in painting.webp depth.png theater.json; do

--- a/.github/workflows/theater_bake.yml
+++ b/.github/workflows/theater_bake.yml
@@ -104,8 +104,18 @@ jobs:
       - name: Bake theater layers
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # Passed via env, not spliced directly into the script below as
+          # `${{ github.event.inputs.ids }}` — GitHub Actions substitutes
+          # `${{ }}` expressions into the run script's TEXT before the
+          # shell ever parses it, so a filename-derived id containing shell
+          # metacharacters (quotes, semicolons, backticks) would otherwise
+          # be able to break out and run arbitrary commands in a job that
+          # has contents:write and HF_TOKEN in scope. Referencing $IDS_INPUT
+          # below is a normal bash variable expansion instead — no
+          # pre-parse substitution, no injection.
+          IDS_INPUT: ${{ github.event.inputs.ids }}
         run: |
-          IDS="${{ github.event.inputs.ids }}"
+          IDS="$IDS_INPUT"
           if [ -z "$IDS" ]; then IDS="$DEFAULT_IDS"; fi
           echo "Baking: $IDS"
           python scripts/theater_baker.py \

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,8 +1,16 @@
 # Frontend Architecture
 
-Plain **Vite + React 18**, no meta-framework (no Next.js, no router beyond
-the one unused `wouter` dependency — this is a single-route
-experience). 3D via **Three.js** through **@react-three/fiber** (R3F) and
+Plain **Vite + React 18**, no meta-framework (no Next.js). Routing is
+**wouter** (`src/App.jsx`'s `<Switch>`): `/` is the gallery (unchanged, and
+still what most visitors get — `/admin` and `/projects` are
+`React.lazy`-loaded so their code never reaches a gallery visitor's
+bundle), `/admin` is the content-management PWA (`src/admin/`, gated on a
+GitHub token, not linked from the gallery UI), `/projects` cross-links the
+owner's other GitHub Pages repos (`src/projects/ProjectsPage.jsx`). GitHub
+Pages has no server-side SPA fallback, so a direct load of `/admin` or
+`/projects` is caught by `public/404.html`, which stashes the path and
+bounces to `/`; `src/main.jsx` restores it before wouter reads
+`window.location`. 3D via **Three.js** through **@react-three/fiber** (R3F) and
 **@react-three/drei**'s helpers (`ScrollControls`, `useScroll`, `Loader`,
 `PerspectiveCamera`). State via **Zustand**. See
 [`ARCHITECTURE.md`](./ARCHITECTURE.md) for how these pieces fit into the
@@ -20,13 +28,16 @@ src/
 │   └── useStore.jsx                Zustand: graph, segments, hinge placement, walk logic
 ├── utils/
 │   └── Logger.js                   console hijack + crash log ring buffer + GitHub issue URL
-└── components/
-    ├── JulesBoundary.jsx            top-level React error boundary
-    ├── Scene.jsx                    <Canvas>, data loading, background sweep mesh
-    ├── AnamorphicCam.jsx            scroll → camera position/gaze, keyboard nav, reduced motion
-    ├── TheaterPainting.jsx          per-painting depth-band renderer (the shader lives here)
-    ├── TexturePreloader.jsx         warms upcoming paintings' textures ahead of the scroll
-    └── Overlay.jsx                  2D DOM UI: signature, caption, menu modal, load-error text
+├── components/
+│   ├── JulesBoundary.jsx            top-level React error boundary
+│   ├── Scene.jsx                    <Canvas>, data loading, background sweep mesh
+│   ├── AnamorphicCam.jsx            scroll → camera position/gaze, keyboard nav, reduced motion
+│   ├── TheaterPainting.jsx          per-painting depth-band renderer (the shader lives here)
+│   ├── TexturePreloader.jsx         warms upcoming paintings' textures ahead of the scroll
+│   └── Overlay.jsx                  2D DOM UI: signature, caption, menu modal, load-error text
+├── admin/                          /admin — content-management PWA (see below)
+└── projects/
+    └── ProjectsPage.jsx             /projects — cross-links other GitHub Pages repos
 ```
 
 There is no `src/canvas/`, `src/shaders/`, or `src/ui/` — despite what
@@ -163,3 +174,31 @@ that have to agree between the camera, the world-placement math, and the
 rendered plane geometry for a painting to reassemble exactly at its
 null. Previously hand-duplicated across three files (correct only by
 discipline); now a single shared source of truth all three import.
+
+### `src/admin/` (`/admin`) and `src/projects/` (`/projects`)
+
+Two routes outside the gallery, both `React.lazy`-loaded from `App.jsx` so
+a normal gallery visitor's bundle never grows because of them.
+
+`/admin` is a mobile-first content-management PWA: paste a GitHub
+fine-grained personal access token once (`TokenSetup.jsx`, stored in
+`localStorage`, never sent anywhere but the GitHub REST API) and then
+add/remove paintings and edit their metadata, or edit
+`public/site-content.json` (the gallery menu's links/about text), all via
+direct browser calls to the Contents and Actions APIs (`github.js`) — no
+backend. Adding a painting commits the photo to `public/assets/` and
+dispatches `theater_bake.yml`; removing one deletes the source photo and
+dispatches `remove_painting.yml`. Neither workflow's completion is waited
+on synchronously — the admin UI reports "dispatched," and the actual
+bake/removal + redeploy runs in the background over the next few minutes
+(see `.github/workflows/`).
+
+`/admin` is deliberately not linked anywhere in the gallery UI or its
+menu — reached only by navigating to it directly. The token is the real
+access control; not advertising the URL is a cheap extra layer, not a
+security boundary on its own.
+
+`/projects` fetches `https://api.github.com/users/HereLiesAz/repos`
+directly and unauthenticated at page load, and lists every repo with
+GitHub Pages enabled as a card — no build step, no staleness, no token.
+It's linked from the gallery's menu modal (`Overlay.jsx`).

--- a/public/404.html
+++ b/public/404.html
@@ -10,7 +10,9 @@
   // deploy target already has. Stash the intended path and bounce to the
   // real app shell, which restores it before the router mounts (see
   // main.jsx). Standard technique: https://github.com/rafgraph/spa-github-pages
-  sessionStorage.setItem('spaRedirect', location.pathname + location.search + location.hash);
+  try {
+    sessionStorage.setItem('spaRedirect', location.pathname + location.search + location.hash);
+  } catch (e) { /* storage unavailable — redirect to "/" anyway, just without restoring the path */ }
   location.replace('/');
 </script>
 </body>

--- a/scripts/theater_baker.py
+++ b/scripts/theater_baker.py
@@ -590,17 +590,30 @@ def bake_image(path: Path, out_dir: Path, max_side: int, force: bool = False) ->
     # ids whose box changed — no blanket --force when a few crops move.
     directive = crop_directive(pid)
     prev_directive = "MISSING"
+    prev_src_size = None
     crop_note = None  # carried over from a cached bake unless recomputed below
     if out_json.exists():
         try:
             prev_meta = json.loads(out_json.read_text())
             prev_directive = prev_meta.get("crop", "MISSING")
             crop_note = prev_meta.get("crop_note")
+            prev_src_size = prev_meta.get("src", {}).get("size")
         except Exception:
             pass
     crop_changed = prev_directive != directive
+    # A different photo uploaded under the same id (filename stem) — e.g.
+    # a generic camera name like "IMG_0232" recurring across devices —
+    # would otherwise pass crop_changed=False (same, usually-default
+    # directive) and silently reuse the OLD photo's cached painting/depth
+    # while meta["src"]["image"] below records the NEW filename: a
+    # theater.json whose pixels and provenance disagree. prev_src_size is
+    # None for a theater.json baked before this field existed, in which
+    # case there's nothing to compare against — that's a one-time gap for
+    # already-baked ids, not a reason to force a full corpus re-bake.
+    source_changed = prev_src_size is not None and prev_src_size != path.stat().st_size
+    cache_valid = not force and not crop_changed and not source_changed
 
-    if out_painting.exists() and not force and not crop_changed:
+    if out_painting.exists() and cache_valid:
         rgb = np.array(ImageOps.exif_transpose(Image.open(out_painting)).convert("RGB"))
     else:
         # The raw source photo — the one place in the pipeline where a
@@ -636,7 +649,7 @@ def bake_image(path: Path, out_dir: Path, max_side: int, force: bool = False) ->
     # a reliable local depth model is the primary path.
     depth = None
     source = None
-    if out_depth.exists() and not force and not crop_changed:
+    if out_depth.exists() and cache_valid:
         # Default to UNTRUSTED ("synthetic") rather than "assume real". A
         # cache hit is only a fast-path when we can actually confirm the
         # cached depth.png came from a real model; any failure to read
@@ -656,12 +669,13 @@ def bake_image(path: Path, out_dir: Path, max_side: int, force: bool = False) ->
             source = cached_source
 
     if depth is None:
-        # force here covers BOTH a hand-authored --force AND a detected
-        # crop change: crop_changed already invalidated the out_painting/
-        # out_depth caches above, so `rgb` may be a different composition
-        # than whatever produced a stale out_photo — photorealize's own
-        # cache check must be told that explicitly (see its docstring).
-        photo = photorealize(rgb, out_photo, force=force or crop_changed)
+        # force here covers a hand-authored --force, a detected crop
+        # change, AND a detected source-photo change: any of the three
+        # already invalidated the out_painting/out_depth caches above, so
+        # `rgb` may be a different composition than whatever produced a
+        # stale out_photo — photorealize's own cache check must be told
+        # that explicitly (see its docstring).
+        photo = photorealize(rgb, out_photo, force=force or crop_changed or source_changed)
         src_img = photo if photo is not None else rgb
         # Local Depth-Anything first (reliable), Space second, synth last.
         depth = estimate_depth_local(src_img)
@@ -693,7 +707,10 @@ def bake_image(path: Path, out_dir: Path, max_side: int, force: bool = False) ->
     meta = {
         "schema": 2,
         "id":     pid,
-        "src":    {"image": path.name, "width": w, "height": h},
+        # "size" (source file bytes) lets a future bake detect a different
+        # photo uploaded under the same id (filename stem) even when the
+        # crop directive is unchanged — see cache_valid/source_changed above.
+        "src":    {"image": path.name, "width": w, "height": h, "size": path.stat().st_size},
         # The crop directive applied in stage A (normalized box, null for
         # keep-whole, or "heuristic"). Recorded so a re-bake can detect when a
         # box changed and re-crop + re-derive depth for just that id.

--- a/scripts/validate_output.py
+++ b/scripts/validate_output.py
@@ -61,6 +61,8 @@ import json
 import sys
 from pathlib import Path
 
+from PIL import Image
+
 errors: list[str] = []
 
 
@@ -85,13 +87,39 @@ def validate_theater_json(path: Path) -> None:
 
     src = data.get("src")
     check(isinstance(src, dict), f"{name}: missing/invalid 'src'")
+    valid_dims = False
     if isinstance(src, dict):
         check("width" in src and "height" in src,
               f"{name}: src missing width/height")
-        check(isinstance(src.get("width"), (int, float)) and src.get("width", 0) > 0,
-              f"{name}: src.width is not a positive number")
-        check(isinstance(src.get("height"), (int, float)) and src.get("height", 0) > 0,
-              f"{name}: src.height is not a positive number")
+        valid_dims = (isinstance(src.get("width"), (int, float)) and src.get("width", 0) > 0
+                      and isinstance(src.get("height"), (int, float)) and src.get("height", 0) > 0)
+        check(valid_dims, f"{name}: src.width/height is not a positive number")
+
+    # {id}.painting.webp is saved directly at (src.height, src.width) by
+    # theater_baker.py's bake_image() — no resize happens after that save,
+    # so its actual pixel dimensions must exactly match src.width/height.
+    # A mismatch means this theater.json's provenance doesn't match the
+    # image it's shipping alongside — the exact shape a stale cache-reuse
+    # bug (an id/filename collision reusing an old painting.webp while
+    # recording a new photo's filename) would take. Not checked against
+    # {id}.depth.png: theater_baker.py's load_depth_png() legitimately
+    # resizes a cached depth map to match the current painting's shape, so
+    # a differing on-disk depth.png resolution is expected, not an error.
+    if valid_dims:
+        painting_path = path.parent / f"{path.name[:-len('.theater.json')]}.painting.webp"
+        if painting_path.exists():
+            try:
+                with Image.open(painting_path) as im:
+                    actual_w, actual_h = im.size
+            except Exception as e:
+                check(False, f"{name}: could not read {painting_path.name} to verify "
+                              f"dimensions ({type(e).__name__}: {e})")
+            else:
+                check(actual_w == src["width"] and actual_h == src["height"],
+                      f"{name}: src says {src['width']}x{src['height']} but "
+                      f"{painting_path.name} is actually {actual_w}x{actual_h} — "
+                      f"provenance doesn't match the baked pixels (stale cache reuse "
+                      f"under an id/filename collision?)")
 
     depth = data.get("depth")
     check(isinstance(depth, dict), f"{name}: missing/invalid 'depth'")

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -250,7 +250,7 @@ const App = () => (
     <Route path="/admin">
       <Suspense fallback={<RouteFallback />}><AdminApp /></Suspense>
     </Route>
-    <Route path="/admin/:rest*">
+    <Route path="/admin/*">
       <Suspense fallback={<RouteFallback />}><AdminApp /></Suspense>
     </Route>
     <Route><Gallery /></Route>

--- a/src/admin/AddPainting.jsx
+++ b/src/admin/AddPainting.jsx
@@ -1,9 +1,21 @@
 import { useState } from 'react';
 import { dispatchWorkflow, fileToBase64, putFile } from './github.js';
 
-function idFromFilename(name) {
+/** Derives both the painting id and the filename actually uploaded from a
+ * picked file's name. The id gets spliced into a comma-joined batch
+ * (theater_bake.yml's `--ids`) and used as a GitHub Contents API path
+ * segment, so it's restricted to a safe, corpus-consistent character set —
+ * a raw filename could contain a comma (corrupts the batch, silently
+ * dropping that painting) or other characters that don't belong in a path
+ * segment. The uploaded filename is rebuilt from the sanitized id (not the
+ * original name) so the file on disk and the id used to bake it always
+ * match. */
+function sanitizeIdAndFilename(name) {
   const i = name.lastIndexOf('.');
-  return i > 0 ? name.slice(0, i) : name;
+  const stem = i > 0 ? name.slice(0, i) : name;
+  const ext = i > 0 ? name.slice(i) : '';
+  const id = stem.replace(/[^A-Za-z0-9._~()-]/g, '_') || 'photo';
+  return { id, filename: `${id}${ext}` };
 }
 
 /** Uploads raw photo(s) to public/assets/ and dispatches theater_bake.yml
@@ -19,21 +31,49 @@ export default function AddPainting() {
   const run = async () => {
     if (files.length === 0) return;
     setStatus('uploading');
-    const ids = [];
-    try {
-      for (const file of files) {
-        const id = idFromFilename(file.name);
+    const uploaded = [];
+    const remaining = [...files];
+    let uploadError = null;
+
+    // Sequential, not Promise.all: each successfully-uploaded file is a
+    // real, non-rollback-able commit to main. On a failure partway
+    // through, stop rather than continue committing more files under an
+    // error the user hasn't seen yet — and only remove the files that
+    // actually succeeded from the picker, so a retry doesn't re-attempt
+    // putFile on a path that now exists without a sha (which the Contents
+    // API rejects).
+    while (remaining.length > 0) {
+      const file = remaining[0];
+      const { id, filename } = sanitizeIdAndFilename(file.name);
+      try {
         const b64 = await fileToBase64(file);
-        await putFile(`public/assets/${file.name}`, b64, `admin: add painting ${id}`);
-        ids.push(id);
+        await putFile(`public/assets/${filename}`, b64, `admin: add painting ${id}`);
+        uploaded.push(id);
+        remaining.shift();
+      } catch (e) {
+        uploadError = e;
+        break;
       }
+    }
+    setFiles(remaining);
+
+    if (uploaded.length > 0) {
       setStatus('baking');
-      await dispatchWorkflow('theater_bake.yml', { ids: ids.join(',') });
-      setDispatchedIds(ids);
+      try {
+        await dispatchWorkflow('theater_bake.yml', { ids: uploaded.join(',') });
+        setDispatchedIds(uploaded);
+      } catch (e) {
+        setStatus({ error: `Uploaded ${uploaded.join(', ')} but failed to dispatch the bake: ${e.message}. The photo(s) are on main — dispatch theater_bake.yml by hand with these ids, or retry once the underlying issue is fixed.` });
+        return;
+      }
+    }
+
+    if (uploadError) {
+      setStatus({
+        error: `${uploaded.length ? `Uploaded and dispatched ${uploaded.join(', ')}, but stopped` : 'Stopped'} after a failure: ${uploadError.message}. ${remaining.length} file(s) left in the picker — fix the issue and click upload again.`,
+      });
+    } else {
       setStatus('done');
-      setFiles([]);
-    } catch (e) {
-      setStatus({ error: e.message });
     }
   };
 
@@ -47,6 +87,7 @@ export default function AddPainting() {
         multiple
         onChange={e => setFiles(Array.from(e.target.files || []))}
         className="admin-input"
+        aria-label="select painting photos"
       />
       {files.length > 0 && (
         <ul className="admin-file-list">
@@ -59,14 +100,14 @@ export default function AddPainting() {
         </button>
       </div>
       {status === 'done' && (
-        <p className="admin-ok">
+        <p className="admin-ok" role="status" aria-live="polite">
           Uploaded and dispatched: {dispatchedIds.join(', ')}.{' '}
           <a href={`https://github.com/HereLiesAz/hereliesaz.github.io/actions/workflows/theater_bake.yml`} target="_blank" rel="noreferrer noopener">
             watch the bake run
           </a>.
         </p>
       )}
-      {status?.error && <p className="admin-error">{status.error}</p>}
+      {status?.error && <p className="admin-error" role="alert">{status.error}</p>}
     </div>
   );
 }

--- a/src/admin/AdminApp.jsx
+++ b/src/admin/AdminApp.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'wouter';
 import { hasToken } from './github.js';
 import TokenSetup from './TokenSetup.jsx';
 import PaintingsList from './PaintingsList.jsx';
@@ -24,7 +25,7 @@ const STYLES = `
 .admin-nav button {
   background: transparent; border: 1px solid rgba(244,240,230,0.3); color: #f4f0e6;
   padding: 0.4em 0.9em; font-family: inherit; text-transform: lowercase; letter-spacing: 0.08em;
-  cursor: pointer; font-size: 0.8rem;
+  cursor: pointer; font-size: 0.8rem; min-height: 44px;
 }
 .admin-nav button[data-active="true"] { background: #f4f0e6; color: #0a0a0a; }
 .admin-panel { max-width: 42rem; }
@@ -36,10 +37,10 @@ const STYLES = `
   width: 100%; box-sizing: border-box; background: #141414; border: 1px solid rgba(244,240,230,0.25);
   color: #f4f0e6; font-family: inherit; font-size: 0.85rem; padding: 0.5em 0.6em; margin-top: 0.2em;
 }
-.admin-row { display: flex; gap: 0.6em; align-items: center; margin: 0.6em 0; flex-wrap: wrap; }
+.admin-row { display: flex; gap: 0.8em; align-items: center; margin: 0.6em 0; flex-wrap: wrap; }
 .admin-row--between { justify-content: space-between; }
 button { background: #f4f0e6; color: #0a0a0a; border: none; padding: 0.5em 1em; font-family: inherit;
-  text-transform: lowercase; letter-spacing: 0.06em; cursor: pointer; font-size: 0.8rem; }
+  text-transform: lowercase; letter-spacing: 0.06em; cursor: pointer; font-size: 0.8rem; min-height: 44px; }
 button:disabled { opacity: 0.5; cursor: default; }
 .admin-btn-danger { background: #3a1414; color: #f4b0b0; }
 .admin-btn-plain { background: transparent; color: #f4f0e6; border: 1px solid rgba(244,240,230,0.3); }
@@ -82,16 +83,27 @@ export default function AdminApp() {
 
   return (
     <div className="admin-shell">
-      <nav className="admin-nav">
+      <nav className="admin-nav" role="tablist">
         {TABS.map(t => (
-          <button type="button" key={t} data-active={tab === t} onClick={() => setTab(t)}>{t}</button>
+          <button
+            type="button"
+            key={t}
+            role="tab"
+            id={`admin-tab-${t}`}
+            aria-selected={tab === t}
+            aria-controls={`admin-tabpanel-${t}`}
+            data-active={tab === t}
+            onClick={() => setTab(t)}
+          >{t}</button>
         ))}
-        <a href="/" className="admin-btn-plain" style={{ marginLeft: 'auto', textDecoration: 'none', padding: '0.4em 0.9em', fontSize: '0.8rem' }}>← gallery</a>
+        <Link href="/" className="admin-btn-plain" style={{ marginLeft: 'auto', textDecoration: 'none', padding: '0.4em 0.9em', fontSize: '0.8rem' }}>← gallery</Link>
       </nav>
-      {tab === 'paintings' && <PaintingsList />}
-      {tab === 'add' && <AddPainting />}
-      {tab === 'site' && <SiteContentEditor />}
-      {tab === 'settings' && <TokenSetup onVerified={() => setAuthed(true)} />}
+      <div role="tabpanel" id={`admin-tabpanel-${tab}`} aria-labelledby={`admin-tab-${tab}`}>
+        {tab === 'paintings' && <PaintingsList />}
+        {tab === 'add' && <AddPainting />}
+        {tab === 'site' && <SiteContentEditor />}
+        {tab === 'settings' && <TokenSetup onVerified={() => setAuthed(true)} />}
+      </div>
     </div>
   );
 }

--- a/src/admin/PaintingEditor.jsx
+++ b/src/admin/PaintingEditor.jsx
@@ -33,6 +33,14 @@ export default function PaintingEditor({ id, onClose, onRemoved }) {
   const set = (key) => (e) => setForm(f => ({ ...f, [key]: e.target.type === 'checkbox' ? e.target.checked : e.target.value }));
 
   const save = async () => {
+    if (form.forSale && form.price === '') {
+      setStatus({ error: 'Marked "for sale" needs a price — the gallery caption has nothing to show without one.' });
+      return;
+    }
+    if (form.forSale && Number(form.price) < 0) {
+      setStatus({ error: 'Price can\'t be negative.' });
+      return;
+    }
     setStatus('saving');
     try {
       const entry = {
@@ -40,7 +48,7 @@ export default function PaintingEditor({ id, onClose, onRemoved }) {
         description: form.description.trim(),
         tags: form.tags.split(',').map(t => t.trim()).filter(Boolean),
         forSale: !!form.forSale,
-        ...(form.forSale && form.price !== '' ? { price: Number(form.price), currency: form.currency.trim() || 'USD' } : {}),
+        ...(form.forSale && form.price !== '' ? { price: Number(form.price), currency: form.currency.trim().toUpperCase() || 'USD' } : {}),
       };
       await saveMetaEntry(id, entry);
       setStatus('saved');
@@ -62,7 +70,13 @@ export default function PaintingEditor({ id, onClose, onRemoved }) {
       // user next hits refresh.
       setStatus('removed');
     } catch (e) {
-      setStatus({ error: e.message });
+      // removePainting() dispatches the actual removal first and only
+      // throws afterward (with `.dispatched = true`) if a secondary
+      // cleanup step (source photo delete, metadata strip) failed — the
+      // painting is still going away, just with loose ends. Show both:
+      // the removal confirmation AND the cleanup error, not just one.
+      if (e.dispatched) setStatus({ removedWithWarning: e.message });
+      else setStatus({ error: e.message });
     }
   };
 
@@ -90,20 +104,20 @@ export default function PaintingEditor({ id, onClose, onRemoved }) {
       </label>
       {form.forSale && (
         <div className="admin-row">
-          <input className="admin-input" style={{ maxWidth: '8rem' }} type="number" min="0" step="1" value={form.price} onChange={set('price')} placeholder="price" />
-          <input className="admin-input" style={{ maxWidth: '6rem' }} value={form.currency} onChange={set('currency')} placeholder="USD" />
+          <input className="admin-input" style={{ maxWidth: '8rem' }} type="number" min="0" step="1" value={form.price} onChange={set('price')} placeholder="price" aria-label="price" />
+          <input className="admin-input" style={{ maxWidth: '6rem' }} value={form.currency} onChange={set('currency')} placeholder="USD" aria-label="currency" />
         </div>
       )}
 
       <div className="admin-row">
-        <button type="button" onClick={save} disabled={status === 'saving' || status === 'removed'}>{status === 'saving' ? 'saving…' : 'save'}</button>
-        <button type="button" onClick={remove} disabled={status === 'removing' || status === 'removed'} className="admin-btn-danger">
-          {status === 'removing' ? 'removing…' : status === 'removed' ? 'removal dispatched' : 'remove from site'}
+        <button type="button" onClick={save} disabled={status === 'saving' || status === 'removed' || (status && status.removedWithWarning)}>{status === 'saving' ? 'saving…' : 'save'}</button>
+        <button type="button" onClick={remove} disabled={status === 'removing' || status === 'removed' || (status && status.removedWithWarning)} className="admin-btn-danger">
+          {status === 'removing' ? 'removing…' : (status === 'removed' || (status && status.removedWithWarning)) ? 'removal dispatched' : 'remove from site'}
         </button>
       </div>
-      {status === 'saved' && <p className="admin-ok">Saved — live after the next deploy (usually under a minute).</p>}
-      {status === 'removed' && (
-        <p className="admin-ok">
+      {status === 'saved' && <p className="admin-ok" role="status" aria-live="polite">Saved — live after the next deploy (usually under a minute).</p>}
+      {(status === 'removed' || (status && status.removedWithWarning)) && (
+        <p className="admin-ok" role="status" aria-live="polite">
           Removal dispatched — this takes a few minutes to actually run (delete the baked files, rebuild the
           hinge graph, redeploy).{' '}
           <a href="https://github.com/HereLiesAz/hereliesaz.github.io/actions/workflows/remove_painting.yml" target="_blank" rel="noreferrer noopener">
@@ -111,7 +125,8 @@ export default function PaintingEditor({ id, onClose, onRemoved }) {
           </a>, then <button type="button" className="admin-btn-plain" onClick={() => onRemoved?.(id)}>back to the list</button>.
         </p>
       )}
-      {status?.error && <p className="admin-error">{status.error}</p>}
+      {status?.removedWithWarning && <p className="admin-error" role="alert">{status.removedWithWarning}</p>}
+      {status?.error && <p className="admin-error" role="alert">{status.error}</p>}
     </div>
   );
 }

--- a/src/admin/PaintingsList.jsx
+++ b/src/admin/PaintingsList.jsx
@@ -44,6 +44,7 @@ export default function PaintingsList() {
       <input
         className="admin-input"
         placeholder="filter…"
+        aria-label="filter paintings"
         value={filter}
         onChange={e => setFilter(e.target.value)}
       />

--- a/src/admin/SiteContentEditor.jsx
+++ b/src/admin/SiteContentEditor.jsx
@@ -69,8 +69,8 @@ export default function SiteContentEditor() {
       <div className="admin-row">
         <button type="button" onClick={save} disabled={status === 'saving'}>{status === 'saving' ? 'saving…' : 'save'}</button>
       </div>
-      {status === 'saved' && <p className="admin-ok">Saved — live after the next deploy (usually under a minute).</p>}
-      {status?.error && <p className="admin-error">{status.error}</p>}
+      {status === 'saved' && <p className="admin-ok" role="status" aria-live="polite">Saved — live after the next deploy (usually under a minute).</p>}
+      {status?.error && <p className="admin-error" role="alert">{status.error}</p>}
     </div>
   );
 }

--- a/src/admin/TokenSetup.jsx
+++ b/src/admin/TokenSetup.jsx
@@ -14,8 +14,14 @@ export default function TokenSetup({ onVerified }) {
     try {
       const info = await verifyToken();
       const canWrite = !!info.permissions?.push;
-      setStatus(canWrite ? 'ok' : { error: `Token works but has no write access to this repo (logged in as ${info.login}). Check the token's repository permissions.` });
-      if (canWrite) onVerified?.();
+      if (!canWrite) {
+        setStatus({ error: `Token works but has no write access to this repo (logged in as ${info.login}). Check the token's repository permissions.` });
+      } else if (!info.actionsOk) {
+        setStatus({ error: `Token has Contents write access but no Actions permission (logged in as ${info.login}) — adding or removing a painting dispatches a workflow, which needs Actions: Read and write too. Edit the token's permissions on GitHub and try again.` });
+      } else {
+        setStatus('ok');
+        onVerified?.();
+      }
     } catch (e) {
       setStatus({ error: e.message });
     }
@@ -42,6 +48,7 @@ export default function TokenSetup({ onVerified }) {
         autoComplete="off"
         spellCheck={false}
         placeholder="github_pat_…"
+        aria-label="GitHub personal access token"
         value={value}
         onChange={e => setValue(e.target.value)}
         className="admin-input"
@@ -52,8 +59,8 @@ export default function TokenSetup({ onVerified }) {
         </button>
         {getToken() && <button type="button" onClick={clear} className="admin-btn-danger">clear token</button>}
       </div>
-      {status === 'ok' && <p className="admin-ok">Verified — write access confirmed.</p>}
-      {status?.error && <p className="admin-error">{status.error}</p>}
+      {status === 'ok' && <p className="admin-ok" role="status" aria-live="polite">Verified — write access confirmed.</p>}
+      {status?.error && <p className="admin-error" role="alert">{status.error}</p>}
     </div>
   );
 }

--- a/src/admin/data.js
+++ b/src/admin/data.js
@@ -56,23 +56,52 @@ export async function fetchTheaterMeta(id) {
   return res.ok ? res.json() : null;
 }
 
-/** Full removal: delete the source photo from main (if we can find it —
- * a painting that failed to bake yet has no theater.json to read the
- * filename from, in which case this step is skipped rather than blocking
- * the rest of the cleanup), strip its metadata, then dispatch
- * remove_painting.yml to clean up the baked artifacts + hinge graph on
- * art-data. The workflow run is async — this only confirms dispatch, not
- * completion (see AdminApp's link to the Actions run). */
+/** Full removal: dispatch remove_painting.yml (cleans up the baked
+ * artifacts + hinge graph on art-data — the part that actually makes the
+ * painting disappear from the live site) FIRST, then attempt the two
+ * secondary cleanup steps (delete the source photo from main, strip its
+ * metadata entry) independently of each other. Ordering matters: if the
+ * dispatch itself fails, nothing has changed yet, so the whole thing is
+ * safely retryable. If a secondary step fails after a successful dispatch,
+ * the real removal still proceeds — a stale source photo or metadata
+ * entry is a nuisance, not a failed removal — and the failure is reported,
+ * not swallowed, so it doesn't look like a clean success.
+ *
+ * getFile() already distinguishes "file doesn't exist" (returns null) from
+ * a real error (throws) — do not wrap it in a blanket .catch(() => null)
+ * here, or an expired token / rate limit / 5xx gets misread as "no source
+ * photo to delete" and silently skipped. */
 export async function removePainting(id) {
-  const theaterMeta = await fetchTheaterMeta(id).catch(() => null);
-  const srcImage = theaterMeta?.src?.image;
-  if (srcImage) {
-    const path = `public/assets/${srcImage}`;
-    const file = await getFile(path).catch(() => null);
-    if (file) await deleteFile(path, `admin: remove source photo for ${id}`, file.sha);
-  }
-  await saveMetaEntry(id, null);
   await dispatchWorkflow('remove_painting.yml', { id });
+
+  const errors = [];
+
+  try {
+    const theaterMeta = await fetchTheaterMeta(id).catch(() => null);
+    const srcImage = theaterMeta?.src?.image;
+    if (srcImage) {
+      const path = `public/assets/${srcImage}`;
+      const file = await getFile(path);
+      // [skip-grind]: this is a real push to public/assets/**, which would
+      // otherwise also kick off process_art.yml's 56-shard legacy grinder
+      // for a file being deleted — see that workflow's job-level `if:`.
+      if (file) await deleteFile(path, `admin: remove source photo for ${id} [skip-grind]`, file.sha);
+    }
+  } catch (e) {
+    errors.push(`source photo: ${e.message}`);
+  }
+
+  try {
+    await saveMetaEntry(id, null);
+  } catch (e) {
+    errors.push(`metadata: ${e.message}`);
+  }
+
+  if (errors.length) {
+    const err = new Error(`Removal dispatched (the painting will still disappear from the site), but cleanup had errors — you may want to retry these by hand: ${errors.join('; ')}`);
+    err.dispatched = true;
+    throw err;
+  }
 }
 
 export { META_PATH, SITE_PATH };

--- a/src/admin/github.js
+++ b/src/admin/github.js
@@ -33,16 +33,27 @@ class GitHubApiError extends Error {
 async function api(path, options = {}) {
   const token = getToken();
   if (!token) throw new GitHubApiError('No GitHub token set — open Settings first.', 401);
-  const res = await fetch(`https://api.github.com${path}`, {
-    ...options,
-    headers: {
-      Accept: 'application/vnd.github+json',
-      Authorization: `Bearer ${token}`,
-      'X-GitHub-Api-Version': '2022-11-28',
-      ...(options.body ? { 'Content-Type': 'application/json' } : {}),
-      ...options.headers,
-    },
-  });
+  let res;
+  try {
+    res = await fetch(`https://api.github.com${path}`, {
+      ...options,
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+        ...options.headers,
+      },
+    });
+  } catch {
+    // fetch() itself throws (not an HTTP error response) on a network
+    // failure — offline, DNS, CORS-blocked, etc. — before any of the
+    // status-code handling below ever runs. Without this, every admin
+    // panel surfaces the bare browser string ("Failed to fetch",
+    // "NetworkError when attempting to fetch resource") with no
+    // indication of what to actually do about it.
+    throw new GitHubApiError('Could not reach GitHub — check your connection and try again.', 0);
+  }
   if (!res.ok) {
     let detail = '';
     try { detail = (await res.json())?.message || ''; } catch { /* non-JSON error body */ }
@@ -133,10 +144,29 @@ export async function listWorkflowRuns(workflowFile, perPage = 5) {
 
 /** Verifies the stored token actually works and can see this repo,
  * without requiring any specific scope up front — TokenSetup uses this
- * to give immediate, concrete feedback instead of a silent save. */
+ * to give immediate, concrete feedback instead of a silent save.
+ *
+ * Also probes Actions access via a read-only call (listing workflows) —
+ * `data.permissions` from the repo-info endpoint only reflects
+ * Contents/collaborator-level push access, never the separate Actions
+ * scope that dispatchWorkflow() actually needs. Without this, a token
+ * with only "Contents" checked (not "Actions") passes verification
+ * cleanly here and then fails with a 403 the first time the admin app
+ * tries to add or remove a painting — this catches that up front instead.
+ * This can only confirm Actions *read* access (listing workflows needs
+ * nothing more), not write — verifying dispatch itself would mean
+ * actually triggering a workflow just to check, which this deliberately
+ * doesn't do. */
 export async function verifyToken() {
   const data = await api(`/repos/${OWNER}/${REPO}`);
-  return { login: data.owner?.login, permissions: data.permissions };
+  let actionsOk = true;
+  try {
+    await api(`/repos/${OWNER}/${REPO}/actions/workflows`);
+  } catch (e) {
+    if (e.status === 403 || e.status === 404) actionsOk = false;
+    else throw e;
+  }
+  return { login: data.owner?.login, permissions: data.permissions, actionsOk };
 }
 
 export { OWNER, REPO, BRANCH, GitHubApiError };

--- a/src/components/Overlay.jsx
+++ b/src/components/Overlay.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { Link } from 'wouter';
 import useStore from '../store/useStore';
 import { bgSweepLevel } from './TheaterPainting';
 
@@ -312,8 +313,14 @@ const Overlay = () => {
         const info = id ? state.meta?.[id] : null;
         if (titleRef.current) titleRef.current.textContent = info?.title || id || '';
         if (priceRef.current) {
-          priceRef.current.textContent = (info?.forSale && info?.price != null)
-            ? `${info.currency === 'USD' || !info.currency ? '$' : ''}${info.price}${info.currency && info.currency !== 'USD' ? ` ${info.currency}` : ''} — for sale`
+          const price = info?.price;
+          // Case-insensitive on purpose: PaintingEditor.jsx normalizes to
+          // uppercase on save, but this also guards against stale
+          // lowercase entries written before that fix existed.
+          const currency = (info?.currency || 'USD').toUpperCase();
+          const valid = !!info?.forSale && typeof price === 'number' && price >= 0;
+          priceRef.current.textContent = valid
+            ? `${currency === 'USD' ? '$' : ''}${price.toLocaleString()}${currency !== 'USD' ? ` ${currency}` : ''} — for sale`
             : '';
         }
         lastIdRef.current = id;
@@ -410,7 +417,7 @@ const Overlay = () => {
                 <li key={link.href}>
                   {link.external
                     ? <a href={link.href} target="_blank" rel="noreferrer noopener">{link.label}</a>
-                    : <a href={link.href}>{link.label}</a>}
+                    : <Link href={link.href}>{link.label}</Link>}
                 </li>
               ))}
             </ul>

--- a/src/components/TheaterPainting.jsx
+++ b/src/components/TheaterPainting.jsx
@@ -216,7 +216,14 @@ void main() {
     float d = texture2D(uDepth, vUv).r;
     float tear = (vnoise(vUv * 48.0) - 0.5) * 0.05
                + (vnoise(vUv * 320.0) - 0.5) * 0.012;
-    float dj = d + tear;
+    // depth_bands_kmeans() pins the outermost band edges to exactly 0.0/1.0,
+    // and depth is min-max normalized, so real pixels sit right at those
+    // extremes. Without clamping, tear can push dj outside [0,1) for such a
+    // pixel, failing EVERY band's [bandMin, bandMax) test at once — a hole
+    // punched independent of camera position or band assignment. Clamp the
+    // upper end strictly below 1.0 since the last band's test is
+    // dj >= uBandMax with uBandMax == 1.0 exactly.
+    float dj = clamp(d + tear, 0.0, 0.999999);
     bandDiscard = dj < uBandMin || dj >= uBandMax;
   }
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -8,13 +8,17 @@ import './utils/Logger'; // Initialize the logger immediately
 // Restore the path public/404.html stashed before bouncing here (GitHub
 // Pages has no server-side SPA fallback, so a direct nav/reload to a
 // client-side route like /admin lands on 404.html first). Must run before
-// wouter reads window.location below.
-const spaRedirect = sessionStorage.getItem('spaRedirect');
-if (spaRedirect) {
-  sessionStorage.removeItem('spaRedirect');
-  const current = window.location.pathname + window.location.search + window.location.hash;
-  if (spaRedirect !== current) window.history.replaceState(null, '', spaRedirect);
-}
+// wouter reads window.location below. sessionStorage can throw (site data
+// blocked, storage-partitioned contexts) — that must never take down the
+// whole app, including "/", which has no dependency on this at all.
+try {
+  const spaRedirect = sessionStorage.getItem('spaRedirect');
+  if (spaRedirect) {
+    sessionStorage.removeItem('spaRedirect');
+    const current = window.location.pathname + window.location.search + window.location.hash;
+    if (spaRedirect !== current) window.history.replaceState(null, '', spaRedirect);
+  }
+} catch { /* storage unavailable — fall through with whatever URL we already have */ }
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/src/projects/ProjectsPage.jsx
+++ b/src/projects/ProjectsPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Link } from 'wouter';
 
 const STYLES = `
 .projects-shell {
@@ -54,7 +55,11 @@ export default function ProjectsPage() {
             `https://api.github.com/users/${USER}/repos?per_page=100&page=${page}&type=owner`,
             { headers: { Accept: 'application/vnd.github+json' } },
           );
-          if (!res.ok) throw new Error(`GitHub API returned ${res.status}`);
+          if (!res.ok) {
+            throw new Error(res.status === 403
+              ? 'GitHub is rate-limiting this page right now (too many people on your network hit the GitHub API recently) — try again in a bit.'
+              : `GitHub API returned ${res.status}`);
+          }
           const batch = await res.json();
           all.push(...batch);
           if (batch.length < 100) break;
@@ -81,7 +86,7 @@ export default function ProjectsPage() {
   return (
     <div className="projects-shell">
       <div className="projects-header">
-        <a href="/" className="back">← back to the gallery</a>
+        <Link href="/" className="back">← back to the gallery</Link>
         <h1>projects</h1>
         <p>Other things I've built, live wherever they live.</p>
       </div>


### PR DESCRIPTION
## Summary

A requested "glee audit" (adversarial review) ran across six areas of the app — render core/camera, admin app security, routing/app-shell/PWA, CI/CD workflows, the Python bake pipeline, and UX/accessibility. This PR fixes every CONFIRMED finding that survived.

### Render core
- `TheaterPainting.jsx`: the tear-noise term could push a pixel's jittered depth outside `[0,1)` when its true depth sat at the exact band-edge extremes `depth_bands_kmeans()` pins — failing every band's test at once and punching a real, camera-independent hole. Clamped.

### Routing / app shell / PWA
- `main.jsx` + `404.html`: an unguarded `sessionStorage` call could crash the **entire app**, including `/`, in any storage-blocked context. Now guarded.
- `App.jsx`: `/admin/:rest*` isn't wouter's wildcard syntax (that's a bare `*`) — it only matched one path segment, silently falling through to the gallery on a deeper admin URL. Same bug class as the earlier bare-`/admin` fix, one level deeper.
- `Overlay.jsx`, `AdminApp.jsx`, `ProjectsPage.jsx`: internal nav used plain `<a>` instead of wouter's `<Link>`, so every admin/projects nav click did a full page reload through the 404 shim, destroying the live WebGL scene.
- `docs/FRONTEND.md`: updated — it still described the app as single-route with wouter unused.

### CI/CD
- `theater_bake.yml`, `remove_painting.yml`: workflow_dispatch inputs were spliced directly into shell scripts via `${{ }}` — a real script-injection primitive in a job with `contents: write` (+ `HF_TOKEN`). Moved to `env:`.
- `deploy-sftp.yml`: never watched the `Remove Painting` workflow (the exact gap already fixed once for `deploy.yml`), so a removal never redeployed the SFTP mirror. Also added `Bootstrap Art (5 Images)` to both deploy workflows' watch lists.
- `process_art.yml`: deleting a source photo during removal re-triggered the entire 56-shard legacy grinder — the same bug class already fixed for `meta.json`, reintroduced via a delete. Tagged with `[skip-grind]`.

### Python bake pipeline
- `theater_baker.py`: a new photo uploaded under an id that collides with an existing baked filename stem (realistic with generic camera names) silently reused the old cached painting/depth while recording the new filename — a `theater.json` whose provenance doesn't match its pixels. Now also detects a changed source file size.
- `validate_output.py`: added a check that `src.width/height` actually matches the shipped `painting.webp`'s real dimensions, so this class of bug can't ship undetected again.

### Admin app (security, correctness, accessibility)
- Filename sanitization for uploads (a comma in a filename corrupted the bake batch; also closes the same injection surface from the client side).
- Non-atomic upload loop now handles partial failure without abandoning already-uploaded files or silently reporting success.
- Token verification now also checks Actions scope (previously only Contents/push was checked, so a misconfigured token passed setup and then failed on the first dispatch).
- Centralized friendly network-error handling in `github.js`.
- Negative price / "for sale with no price" (silently invisible on the live caption) now rejected before save.
- `removePainting()` no longer masks real errors behind a blanket `.catch(() => null)`, and reports a partial-cleanup failure distinctly from a clean removal instead of losing the "still dispatched" confirmation.
- ARIA tab semantics, `aria-live`/`role="alert"` on async status messages, labels on previously-unlabeled inputs, larger touch targets.

## Test plan

- [x] `npm run build` succeeds
- [x] `python3 -m py_compile` on both touched scripts
- [x] All touched workflow YAML re-parsed successfully
- [ ] On a real device: exercise `/admin` (add, edit metadata incl. negative price/for-sale rejection, remove) and confirm `/projects` still lists correctly
- [ ] Watch a live `theater_bake.yml`/`remove_painting.yml` run to confirm the `env:`-based input passing still works end to end

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_

## Summary by Sourcery

Harden rendering, routing, automation, baking, and administration to resolve confirmed audit findings across the application.

Bug Fixes:
- Prevent shader depth-band holes at normalized depth extremes by clamping jittered depth values.
- Keep the app functional when browser storage is unavailable and correctly restore deep client-side routes, including nested admin paths.
- Preserve the WebGL scene during internal navigation by using client-side routing links.
- Prevent workflow input injection and avoid unnecessary bake runs after painting removals.
- Invalidate stale bake caches when source photos change and validate shipped painting dimensions against metadata.
- Improve admin upload, removal, metadata validation, token verification, network-error reporting, and live status handling.

Enhancements:
- Improve admin accessibility with semantic tabs, live status announcements, input labels, and larger touch targets.
- Keep deployment mirrors synchronized with all workflows that publish art data.
- Update frontend architecture documentation to describe the current routes and app shell.

CI:
- Harden workflow input handling and skip the legacy grinder for removal commits while keeping deployment triggers aligned with art-data publishing workflows.

Documentation:
- Update frontend architecture documentation for wouter routing, the GitHub Pages SPA fallback, and the admin and projects routes.