### PR TITLE
Fix /admin PWA install always reopening the gallery

### DIFF
--- a/public/admin-manifest.json
+++ b/public/admin-manifest.json
@@ -1,0 +1,17 @@
+{
+  "name": "HereLiesAz Admin",
+  "short_name": "HL Admin",
+  "description": "Manage paintings and site content for HereLiesAz.",
+  "start_url": "/admin",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#0a0a0a",
+  "theme_color": "#0a0a0a",
+  "icons": [
+    {
+      "src": "/pwa-icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy, useEffect, useRef, useState } from 'react';
-import { Route, Switch } from 'wouter';
+import { Route, Switch, useLocation } from 'wouter';
 import Scene from './components/Scene';
 import Overlay from './components/Overlay';
 import { Loader } from '@react-three/drei';
@@ -242,19 +242,47 @@ const Gallery = () => {
   );
 };
 
-const App = () => (
-  <Switch>
-    <Route path="/projects">
-      <Suspense fallback={<RouteFallback />}><ProjectsPage /></Suspense>
-    </Route>
-    <Route path="/admin">
-      <Suspense fallback={<RouteFallback />}><AdminApp /></Suspense>
-    </Route>
-    <Route path="/admin/*">
-      <Suspense fallback={<RouteFallback />}><AdminApp /></Suspense>
-    </Route>
-    <Route><Gallery /></Route>
-  </Switch>
-);
+// index.html links exactly one <link rel="manifest">, shared by every
+// route in this single-page app — without this, "Add to Home Screen"
+// from /admin would install a shortcut whose start_url is still "/"
+// (public/manifest.json's), always reopening the gallery instead of
+// /admin regardless of which page was open at install time. Browsers
+// re-evaluate the manifest link's current href at the moment of an
+// install action, not just once on first load, so swapping it here
+// (before the user opens the "install"/"add to home screen" menu) is
+// enough — no reload needed. public/admin-manifest.json has its own
+// start_url ("/admin") and name, but the same scope ("/") as the
+// gallery's manifest, so navigating between routes (e.g. AdminApp's
+// "← gallery" link) stays inside the installed standalone window
+// either way, instead of kicking out to the browser on an out-of-scope
+// navigation.
+function useRouteManifest(pathname) {
+  useEffect(() => {
+    const link = document.querySelector('link[rel="manifest"]');
+    if (!link) return;
+    const href = pathname.startsWith('/admin') ? '/admin-manifest.json' : '/manifest.json';
+    if (link.getAttribute('href') !== href) link.setAttribute('href', href);
+  }, [pathname]);
+}
+
+const App = () => {
+  const [location] = useLocation();
+  useRouteManifest(location);
+
+  return (
+    <Switch>
+      <Route path="/projects">
+        <Suspense fallback={<RouteFallback />}><ProjectsPage /></Suspense>
+      </Route>
+      <Route path="/admin">
+        <Suspense fallback={<RouteFallback />}><AdminApp /></Suspense>
+      </Route>
+      <Route path="/admin/*">
+        <Suspense fallback={<RouteFallback />}><AdminApp /></Suspense>
+      </Route>
+      <Route><Gallery /></Route>
+    </Switch>
+  );
+};
 
 export default App;

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,15 +8,17 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'pwa-icon-512.png'],
-      // index.html already links the real, hand-authored manifest at
-      // /manifest.json (name/colors matching the site's actual branding and
-      // its own <meta name="theme-color">). vite-plugin-pwa's `manifest`
-      // option would generate a SECOND, independent /manifest.webmanifest
-      // and inject a second <link rel="manifest"> unconditionally — it does
-      // not check for or merge with an existing one — leaving two
-      // conflicting manifests in the page with no defined rule for which a
-      // given browser honours. `manifest: false` disables that generation
-      // entirely so public/manifest.json stays the single source of truth.
+      // index.html already links a real, hand-authored manifest — either
+      // /manifest.json (gallery) or /admin-manifest.json (/admin), swapped
+      // at runtime by App.jsx's useRouteManifest() so each installs with
+      // its own start_url. vite-plugin-pwa's `manifest` option would
+      // generate a SEPARATE, independent /manifest.webmanifest and inject
+      // its own <link rel="manifest"> unconditionally — it does not check
+      // for or merge with the existing one — leaving conflicting manifests
+      // in the page with no defined rule for which a given browser
+      // honours. `manifest: false` disables that generation entirely so
+      // the two hand-authored public/*-manifest.json files stay the
+      // single source of truth.
       manifest: false,
       workbox: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg,json,bin,webp}'],


### PR DESCRIPTION
## Summary

- Reported: installing the admin app to the home screen and reopening it later lands on the main gallery page, not `/admin`.
- Root cause: `index.html` links exactly one PWA manifest (`public/manifest.json`, `start_url: "/"`), shared by every route in this single-page app. "Add to Home Screen" from `/admin` still reads that same manifest, so the installed shortcut's `start_url` is always `/`.
- Fix: added `public/admin-manifest.json` with `start_url: "/admin"` (same `scope: "/"` as the gallery manifest, so cross-route navigation like AdminApp's "← gallery" link stays inside the installed standalone window either way). `App.jsx` now swaps which manifest is linked based on the current route (`useRouteManifest`) — browsers re-evaluate the manifest link's live `href` at the moment of an install action, not just on first page load, so this is enough without a reload.
- `vite.config.js`'s comment about the single hand-authored manifest updated to reflect there are now two.

Note for whoever installs this: an `/admin` shortcut installed *before* this ships needs to be removed and reinstalled — the fix doesn't retroactively change an already-installed icon's `start_url`.

## Test plan

- [x] `npm run build` succeeds; `dist/admin-manifest.json` and `dist/manifest.json` both present, both precached (187 → 188 entries)
- [ ] On a real device: uninstall any existing `/admin` home-screen shortcut, reinstall from `/admin`, confirm it reopens `/admin` (not `/`)
- [ ] Confirm a shortcut installed from `/` still opens `/` as before

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3njumqDkUbbKxy3aUD12N)_

## Summary by Sourcery

Ensure PWA shortcuts installed from the admin interface reopen the admin route while retaining the gallery shortcut behavior.

New Features:
- Add a dedicated admin PWA manifest so installations from admin routes reopen at `/admin`.
- Select the appropriate PWA manifest dynamically based on the current route while preserving in-app navigation across routes.

Bug Fixes:
- Fix admin home-screen installations reopening the gallery instead of the admin interface.

Build:
- Document the two hand-authored manifests used alongside the disabled generated PWA manifest.